### PR TITLE
feat: BATI_TEST

### DIFF
--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -365,7 +365,7 @@ async function run() {
       const hooksMap = await retrieveHooks(hooks);
       const meta: VikeMeta = {
         BATI: new Set(flags as Flags[]),
-        BATI_TEST: false,
+        BATI_TEST: process.env.NODE_ENV === "test",
       };
 
       await exec(

--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -365,6 +365,7 @@ async function run() {
       const hooksMap = await retrieveHooks(hooks);
       const meta: VikeMeta = {
         BATI: new Set(flags as Flags[]),
+        BATI_TEST: false,
       };
 
       await exec(

--- a/packages/core/global.d.ts
+++ b/packages/core/global.d.ts
@@ -2,12 +2,14 @@ import type { Flags } from "@batijs/features";
 
 declare global {
   const BATI: Set<Flags>;
+  const BATI_TEST: boolean;
 
   namespace NodeJS {
     interface Global {
       // Reference our above type,
       // this allows global.debug to be used anywhere in our code.
       BATI: Set<Flags>;
+      BATI_TEST: boolean;
     }
   }
 }

--- a/packages/core/global.d.ts
+++ b/packages/core/global.d.ts
@@ -2,14 +2,14 @@ import type { Flags } from "@batijs/features";
 
 declare global {
   const BATI: Set<Flags>;
-  const BATI_TEST: boolean;
+  const BATI_TEST: boolean | undefined;
 
   namespace NodeJS {
     interface Global {
       // Reference our above type,
       // this allows global.debug to be used anywhere in our code.
       BATI: Set<Flags>;
-      BATI_TEST: boolean;
+      BATI_TEST: boolean | undefined;
     }
   }
 }

--- a/packages/core/src/parse.ts
+++ b/packages/core/src/parse.ts
@@ -6,7 +6,11 @@ import type { VikeMeta } from "./types.js";
 
 function guessCodeFormatters(code: string) {
   return {
-    eslint: code.includes("BATI.has") || code.includes("/*# BATI ") || code.includes("@batijs/"),
+    eslint:
+      code.includes("BATI.has") ||
+      code.includes("BATI_TEST") ||
+      code.includes("/*# BATI ") ||
+      code.includes("@batijs/"),
     squirelly: code.includes(tags[0]),
   };
 }

--- a/packages/core/src/parse/eval.ts
+++ b/packages/core/src/parse/eval.ts
@@ -4,8 +4,8 @@ import type { VikeMeta } from "../types.js";
 export type ValidEvalResponse = boolean | "remove-comments-only";
 
 export function evalCondition(code: string, meta: VikeMeta): ValidEvalResponse {
-  const func = new Function(`{ return function(BATI){ return ${code} } };`);
-  const result: unknown = func.call(null).call(null, meta.BATI);
+  const func = new Function(`{ return function(BATI, BATI_TEST){ return ${code} } };`);
+  const result: unknown = func.call(null).call(null, meta.BATI, meta.BATI_TEST);
 
   if (result !== "remove-comments-only" && typeof result !== "boolean") {
     throw new Error("Condition evaluation failed");
@@ -14,19 +14,24 @@ export function evalCondition(code: string, meta: VikeMeta): ValidEvalResponse {
   return result;
 }
 
+function _extractCondition(test: string) {
+  if (!test.includes("BATI.has") && !test.includes("BATI_TEST")) return null;
+
+  return test.replace(/^# /, "").trim();
+}
+
 export function extractBatiCondition(sourceCode: SourceCode, node: { test: { range?: [number, number] } }) {
   if (!node.test.range) return null;
 
   const test = sourceCode.text.slice(node.test.range[0], node.test.range[1]);
-  if (!test.includes("BATI.has")) return null;
 
-  return test.trim();
+  return _extractCondition(test);
 }
 
 export function extractBatiConditionComment(comment: { value: string }) {
   if (!comment.value.includes("BATI.has")) return null;
 
-  return comment.value.replace(/^# /, "").trim();
+  return _extractCondition(comment.value);
 }
 
 export function extractBatiGlobalComment(comment: { value: string }) {

--- a/packages/core/src/parse/eval.ts
+++ b/packages/core/src/parse/eval.ts
@@ -29,8 +29,6 @@ export function extractBatiCondition(sourceCode: SourceCode, node: { test: { ran
 }
 
 export function extractBatiConditionComment(comment: { value: string }) {
-  if (!comment.value.includes("BATI.has")) return null;
-
   return _extractCondition(comment.value);
 }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -4,6 +4,7 @@ export type ContentGetter = () => string | Promise<string>;
 
 export interface VikeMeta {
   BATI: Set<Flags>;
+  BATI_TEST: boolean;
 }
 
 export type TransformerProps = {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -4,7 +4,7 @@ export type ContentGetter = () => string | Promise<string>;
 
 export interface VikeMeta {
   BATI: Set<Flags>;
-  BATI_TEST: boolean;
+  BATI_TEST?: boolean;
 }
 
 export type TransformerProps = {

--- a/packages/core/tests/transform-ts.spec.ts
+++ b/packages/core/tests/transform-ts.spec.ts
@@ -22,6 +22,7 @@ function testIfElse(code: string, expectedIf: string, expectedElseIf?: string, e
       code,
       {
         BATI: new Set(["react"]),
+        BATI_TEST: false,
       },
       { filepath: filename },
     );
@@ -36,6 +37,7 @@ function testIfElse(code: string, expectedIf: string, expectedElseIf?: string, e
         code,
         {
           BATI: new Set(["solid"]),
+          BATI_TEST: false,
         },
         { filepath: filename },
       );
@@ -50,6 +52,7 @@ function testIfElse(code: string, expectedIf: string, expectedElseIf?: string, e
       code,
       {
         BATI: new Set(),
+        BATI_TEST: true,
       },
       { filepath: filename },
     );
@@ -472,4 +475,36 @@ const a = 1;`,
       ),
     ).rejects.toThrow(`Unknown BATI file flag invalid`);
   });
+});
+
+describe("BATI_TEST", () => {
+  testIfElse(
+    `if (BATI_TEST) {
+    content = "test";
+  }`,
+    ``,
+    `content = "test";`,
+  );
+});
+
+describe("BATI_TEST + BATI.has", () => {
+  testIfElse(
+    `if (BATI_TEST || BATI.has("react")) {
+    content = "test";
+  } else if (BATI.has("solid")) {
+    content = "solid";
+  }`,
+    `content = "test";`,
+    `content = "solid";`,
+    `content = "test";`,
+  );
+});
+
+describe("BATI_TEST: comment above import", () => {
+  testIfElse(
+    `//# BATI_TEST
+import "react";`,
+    ``,
+    `import "react";`,
+  );
 });


### PR DESCRIPTION
`BATI_TEST` global is `true` only when running `e2e` tests, `false` otherwise.

```ts
// Works like `BATI.has`, directly in typescript or within comments
if (BATI_TEST) {
  console.log("TEST only");
}

//# BATI_TEST
console.log("TEST only");
```