### PR TITLE
feat: YAML parser

### DIFF
--- a/packages/build/src/index.ts
+++ b/packages/build/src/index.ts
@@ -1,7 +1,7 @@
 import { existsSync } from "node:fs";
 import { mkdir, opendir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
-import { formatCode, transformAndFormat, type Transformer, type VikeMeta } from "@batijs/core";
+import { formatCode, transformAndFormat, type Transformer, type VikeMeta, type YAMLDocument } from "@batijs/core";
 import { mergeDts } from "./merge-dts.js";
 import { queue } from "./queue.js";
 
@@ -59,6 +59,10 @@ async function transformFileAfterExec(filepath: string, fileContent: unknown): P
         return fileContent as string;
       case ".json":
         return JSON.stringify(fileContent, null, 2);
+      case ".yml":
+      case ".yaml":
+        if (typeof fileContent === "string") return fileContent;
+        return (fileContent as YAMLDocument).toString();
     }
   }
   throw new Error(`Unsupported file extension ${parsed.base} (${filepath})`);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -38,7 +38,8 @@
     "unplugin-purge-polyfills": "^0.0.4",
     "vitest": "^2.0.5",
     "vue-eslint-parser": "^9.4.3",
-    "which": "^4.0.0"
+    "which": "^4.0.0",
+    "yaml": "^2.5.0"
   },
   "exports": {
     ".": "./dist/index.js",

--- a/packages/core/src/loaders.ts
+++ b/packages/core/src/loaders.ts
@@ -3,7 +3,16 @@ import { fileURLToPath } from "node:url";
 import { loadFile, parseModule, type ProxifiedModule } from "magicast";
 import { assert } from "./assert.js";
 import { parseReadme } from "./markdown.js";
+import {
+  type Document as YAMLDocument,
+  type DocumentOptions,
+  parseDocument,
+  type ParseOptions,
+  type SchemaOptions,
+} from "yaml";
 import type { TransformerProps } from "./types.js";
+
+export type { YAMLDocument };
 
 export async function loadReadme({ readfile }: TransformerProps) {
   const content = await readfile?.();
@@ -39,4 +48,15 @@ export async function loadRelativeFileAsMagicast<Exports extends object>(
   const __dirname = dirname(__filename);
 
   return loadFile(join(__dirname, relativePath));
+}
+
+export async function loadYaml(
+  { readfile, source, target }: TransformerProps,
+  options?: ParseOptions & DocumentOptions & SchemaOptions,
+) {
+  const content = await readfile?.();
+
+  assert(typeof content === "string", `Unable to load previous YAML module ("${source}" -> "${target}")`);
+
+  return parseDocument(content, options);
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -158,7 +158,7 @@ importers:
         version: 6.2.2
       vike-cloudflare:
         specifier: ^0.0.6
-        version: 0.0.6(vike@0.4.191(react-streaming@0.3.43)(vite@5.4.2(@types/node@18.19.44)))(vite@5.4.2(@types/node@18.19.44))
+        version: 0.0.6(vike@0.4.191(react-streaming@0.3.43(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.2(@types/node@18.19.44)))(vite@5.4.2(@types/node@18.19.44))
       wrangler:
         specifier: ^3.72.1
         version: 3.72.1(@cloudflare/workers-types@4.20240815.0)
@@ -208,7 +208,7 @@ importers:
         version: 0.24.0
       drizzle-orm:
         specifier: ^0.33.0
-        version: 0.33.0(@cloudflare/workers-types@4.20240815.0)(@prisma/client@5.18.0)(@types/better-sqlite3@7.6.11)(@types/react@18.3.3)(better-sqlite3@11.1.2)(react@18.3.1)
+        version: 0.33.0(@cloudflare/workers-types@4.20240815.0)(@prisma/client@5.18.0(prisma@5.18.0))(@types/better-sqlite3@7.6.11)(@types/react@18.3.3)(better-sqlite3@11.1.2)(prisma@5.18.0)(react@18.3.1)
       tsx:
         specifier: ^4.17.0
         version: 4.17.0
@@ -346,13 +346,13 @@ importers:
         version: 2.17.1(express@4.19.2)
       telefunc:
         specifier: ^0.1.76
-        version: 0.1.76(@babel/core@7.25.2)(@babel/parser@7.25.3)(@babel/types@7.25.2)(react-streaming@0.3.43(react@18.3.1))(react@18.3.1)
+        version: 0.1.76(@babel/core@7.25.2)(@babel/parser@7.25.3)(@babel/types@7.25.2)(react-streaming@0.3.43(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       tsx:
         specifier: ^4.17.0
         version: 4.17.0
       vike:
         specifier: ^0.4.191
-        version: 0.4.191(react-streaming@0.3.43)(vite@5.4.2(@types/node@18.19.44))
+        version: 0.4.191(react-streaming@0.3.43(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.2(@types/node@18.19.44))
       vite:
         specifier: ^5.4.2
         version: 5.4.2(@types/node@18.19.44)
@@ -422,13 +422,13 @@ importers:
         version: 4.28.1
       telefunc:
         specifier: ^0.1.76
-        version: 0.1.76(@babel/core@7.25.2)(@babel/parser@7.25.3)(@babel/types@7.25.2)(react-streaming@0.3.43(react@18.3.1))(react@18.3.1)
+        version: 0.1.76(@babel/core@7.25.2)(@babel/parser@7.25.3)(@babel/types@7.25.2)(react-streaming@0.3.43(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       tsx:
         specifier: ^4.17.0
         version: 4.17.0
       vike:
         specifier: ^0.4.191
-        version: 0.4.191(react-streaming@0.3.43)(vite@5.4.2(@types/node@18.19.44))
+        version: 0.4.191(react-streaming@0.3.43(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.2(@types/node@18.19.44))
       vite:
         specifier: ^5.4.2
         version: 5.4.2(@types/node@18.19.44)
@@ -468,7 +468,7 @@ importers:
         version: 6.1.0(firebase@10.13.0)
       vike:
         specifier: ^0.4.191
-        version: 0.4.191(react-streaming@0.3.43)(vite@5.4.2(@types/node@18.19.44))
+        version: 0.4.191(react-streaming@0.3.43(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.2(@types/node@18.19.44))
       vite:
         specifier: ^5.4.2
         version: 5.4.2(@types/node@18.19.44)
@@ -554,13 +554,13 @@ importers:
         version: 1.15.0
       telefunc:
         specifier: ^0.1.76
-        version: 0.1.76(@babel/core@7.25.2)(@babel/parser@7.25.3)(@babel/types@7.25.2)(react-streaming@0.3.43(react@18.3.1))(react@18.3.1)
+        version: 0.1.76(@babel/core@7.25.2)(@babel/parser@7.25.3)(@babel/types@7.25.2)(react-streaming@0.3.43(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       tsx:
         specifier: ^4.17.0
         version: 4.17.0
       vike:
         specifier: ^0.4.191
-        version: 0.4.191(react-streaming@0.3.43)(vite@5.4.2(@types/node@18.19.44))
+        version: 0.4.191(react-streaming@0.3.43(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.2(@types/node@18.19.44))
       vite:
         specifier: ^5.4.2
         version: 5.4.2(@types/node@18.19.44)
@@ -636,10 +636,10 @@ importers:
         version: 0.0.33
       telefunc:
         specifier: ^0.1.76
-        version: 0.1.76(@babel/core@7.25.2)(@babel/parser@7.25.3)(@babel/types@7.25.2)(react-streaming@0.3.43(react@18.3.1))(react@18.3.1)
+        version: 0.1.76(@babel/core@7.25.2)(@babel/parser@7.25.3)(@babel/types@7.25.2)(react-streaming@0.3.43(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       vike:
         specifier: ^0.4.191
-        version: 0.4.191(react-streaming@0.3.43)(vite@5.4.2(@types/node@18.19.44))
+        version: 0.4.191(react-streaming@0.3.43(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.2(@types/node@18.19.44))
       vite:
         specifier: ^5.4.2
         version: 5.4.2(@types/node@18.19.44)
@@ -706,13 +706,13 @@ importers:
         version: 4.5.6
       telefunc:
         specifier: ^0.1.76
-        version: 0.1.76(@babel/core@7.25.2)(@babel/parser@7.25.3)(@babel/types@7.25.2)(react-streaming@0.3.43(react@18.3.1))(react@18.3.1)
+        version: 0.1.76(@babel/core@7.25.2)(@babel/parser@7.25.3)(@babel/types@7.25.2)(react-streaming@0.3.43(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       tsx:
         specifier: ^4.17.0
         version: 4.17.0
       vike:
         specifier: ^0.4.191
-        version: 0.4.191(react-streaming@0.3.43)(vite@5.4.2(@types/node@18.19.44))
+        version: 0.4.191(react-streaming@0.3.43(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.2(@types/node@18.19.44))
       vite:
         specifier: ^5.4.2
         version: 5.4.2(@types/node@18.19.44)
@@ -731,7 +731,7 @@ importers:
         version: link:../drizzle
       '@lucia-auth/adapter-drizzle':
         specifier: ^1.1.0
-        version: 1.1.0(drizzle-orm@0.33.0(@cloudflare/workers-types@4.20240815.0)(@prisma/client@5.18.0)(@types/better-sqlite3@7.6.11)(@types/react@18.3.3)(better-sqlite3@11.1.2)(react@18.3.1))(lucia@3.2.0)
+        version: 1.1.0(drizzle-orm@0.33.0(@cloudflare/workers-types@4.20240815.0)(@prisma/client@5.18.0(prisma@5.18.0))(@types/better-sqlite3@7.6.11)(@types/react@18.3.3)(better-sqlite3@11.1.2)(prisma@5.18.0)(react@18.3.1))(lucia@3.2.0)
       '@lucia-auth/adapter-sqlite':
         specifier: ^3.0.2
         version: 3.0.2(better-sqlite3@11.1.2)(lucia@3.2.0)
@@ -761,13 +761,13 @@ importers:
         version: 16.4.5
       drizzle-orm:
         specifier: ^0.33.0
-        version: 0.33.0(@cloudflare/workers-types@4.20240815.0)(@prisma/client@5.18.0)(@types/better-sqlite3@7.6.11)(@types/react@18.3.3)(better-sqlite3@11.1.2)(react@18.3.1)
+        version: 0.33.0(@cloudflare/workers-types@4.20240815.0)(@prisma/client@5.18.0(prisma@5.18.0))(@types/better-sqlite3@7.6.11)(@types/react@18.3.3)(better-sqlite3@11.1.2)(prisma@5.18.0)(react@18.3.1)
       lucia:
         specifier: ^3.2.0
         version: 3.2.0
       vike:
         specifier: ^0.4.191
-        version: 0.4.191(react-streaming@0.3.43)(vite@5.4.2(@types/node@18.19.44))
+        version: 0.4.191(react-streaming@0.3.43(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.2(@types/node@18.19.44))
       vite:
         specifier: ^5.4.2
         version: 5.4.2(@types/node@18.19.44)
@@ -872,7 +872,7 @@ importers:
         version: 5.5.4
       vike:
         specifier: ^0.4.191
-        version: 0.4.191(react-streaming@0.3.43)(vite@5.4.2(@types/node@18.19.44))
+        version: 0.4.191(react-streaming@0.3.43(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.2(@types/node@18.19.44))
       vike-react:
         specifier: ^0.5.3
         version: 0.5.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vike@0.4.191(react-streaming@0.3.43(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.2(@types/node@18.19.44)))
@@ -918,7 +918,7 @@ importers:
         version: 18.3.1(react@18.3.1)
       vike:
         specifier: ^0.4.191
-        version: 0.4.191(react-streaming@0.3.43)(vite@5.4.2(@types/node@18.19.44))
+        version: 0.4.191(react-streaming@0.3.43(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.2(@types/node@18.19.44))
       vite:
         specifier: ^5.4.2
         version: 5.4.2(@types/node@18.19.44)
@@ -949,7 +949,7 @@ importers:
         version: 18.3.1(react@18.3.1)
       vike:
         specifier: ^0.4.191
-        version: 0.4.191(react-streaming@0.3.43)(vite@5.4.2(@types/node@18.19.44))
+        version: 0.4.191(react-streaming@0.3.43(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.2(@types/node@18.19.44))
       vite:
         specifier: ^5.4.2
         version: 5.4.2(@types/node@18.19.44)
@@ -973,13 +973,13 @@ importers:
         version: 18.19.44
       vike:
         specifier: ^0.4.191
-        version: 0.4.191(react-streaming@0.3.43)(vite@5.4.2(@types/node@18.19.44))
+        version: 0.4.191(react-streaming@0.3.43(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.2(@types/node@18.19.44))
       vite:
         specifier: ^5.4.2
         version: 5.4.2(@types/node@18.19.44)
       vite-plugin-vercel:
         specifier: ^9.0.1
-        version: 9.0.1(@vite-plugin-vercel/vike@9.0.1)(encoding@0.1.13)(vike@0.4.191(react-streaming@0.3.43)(vite@5.4.2(@types/node@18.19.44)))(vite@5.4.2(@types/node@18.19.44))
+        version: 9.0.1(@vite-plugin-vercel/vike@9.0.1)(encoding@0.1.13)(vike@0.4.191(react-streaming@0.3.43(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.2(@types/node@18.19.44)))(vite@5.4.2(@types/node@18.19.44))
 
   boilerplates/shared-no-db:
     dependencies:
@@ -1008,7 +1008,7 @@ importers:
         version: 18.19.44
       vike:
         specifier: ^0.4.191
-        version: 0.4.191(react-streaming@0.3.43)(vite@5.4.2(@types/node@18.19.44))
+        version: 0.4.191(react-streaming@0.3.43(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.2(@types/node@18.19.44))
       vite:
         specifier: ^5.4.2
         version: 5.4.2(@types/node@18.19.44)
@@ -1038,7 +1038,7 @@ importers:
         version: 0.2.3
       vike:
         specifier: ^0.4.191
-        version: 0.4.191(react-streaming@0.3.43)(vite@5.4.2(@types/node@18.19.44))
+        version: 0.4.191(react-streaming@0.3.43(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.2(@types/node@18.19.44))
       vite:
         specifier: ^5.4.2
         version: 5.4.2(@types/node@18.19.44)
@@ -1103,10 +1103,10 @@ importers:
         version: 5.5.4
       vike:
         specifier: ^0.4.191
-        version: 0.4.191(react-streaming@0.3.43)(vite@5.4.2(@types/node@18.19.44))
+        version: 0.4.191(react-streaming@0.3.43(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.2(@types/node@18.19.44))
       vike-solid:
         specifier: ^0.7.2
-        version: 0.7.2(solid-js@1.8.21)(vike@0.4.191(react-streaming@0.3.43)(vite@5.4.2(@types/node@18.19.44)))(vite@5.4.2(@types/node@18.19.44))
+        version: 0.7.2(solid-js@1.8.21)(vike@0.4.191(react-streaming@0.3.43(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.2(@types/node@18.19.44)))(vite@5.4.2(@types/node@18.19.44))
       vite:
         specifier: ^5.4.2
         version: 5.4.2(@types/node@18.19.44)
@@ -1140,7 +1140,7 @@ importers:
         version: 1.8.21
       vike:
         specifier: ^0.4.191
-        version: 0.4.191(react-streaming@0.3.43)(vite@5.4.2(@types/node@18.19.44))
+        version: 0.4.191(react-streaming@0.3.43(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.2(@types/node@18.19.44))
       vite:
         specifier: ^5.4.2
         version: 5.4.2(@types/node@18.19.44)
@@ -1162,7 +1162,7 @@ importers:
         version: 1.8.21
       vike:
         specifier: ^0.4.191
-        version: 0.4.191(react-streaming@0.3.43)(vite@5.4.2(@types/node@18.19.44))
+        version: 0.4.191(react-streaming@0.3.43(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.2(@types/node@18.19.44))
       vite:
         specifier: ^5.4.2
         version: 5.4.2(@types/node@18.19.44)
@@ -1193,7 +1193,7 @@ importers:
         version: 3.4.10
       vike:
         specifier: ^0.4.191
-        version: 0.4.191(react-streaming@0.3.43)(vite@5.4.2(@types/node@18.19.44))
+        version: 0.4.191(react-streaming@0.3.43(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.2(@types/node@18.19.44))
       vite:
         specifier: ^5.4.2
         version: 5.4.2(@types/node@18.19.44)
@@ -1224,10 +1224,10 @@ importers:
         version: 0.2.3
       telefunc:
         specifier: ^0.1.76
-        version: 0.1.76(@babel/core@7.25.2)(@babel/parser@7.25.3)(@babel/types@7.25.2)(react-streaming@0.3.43(react@18.3.1))(react@18.3.1)
+        version: 0.1.76(@babel/core@7.25.2)(@babel/parser@7.25.3)(@babel/types@7.25.2)(react-streaming@0.3.43(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       vike:
         specifier: ^0.4.191
-        version: 0.4.191(react-streaming@0.3.43)(vite@5.4.2(@types/node@18.19.44))
+        version: 0.4.191(react-streaming@0.3.43(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.2(@types/node@18.19.44))
       vite:
         specifier: ^5.4.2
         version: 5.4.2(@types/node@18.19.44)
@@ -1308,16 +1308,16 @@ importers:
         version: 18.19.44
       '@vite-plugin-vercel/vike':
         specifier: ^9.0.1
-        version: 9.0.1(vike@0.4.191(react-streaming@0.3.43)(vite@5.4.2(@types/node@18.19.44)))(vite-plugin-vercel@9.0.1)(vite@5.4.2(@types/node@18.19.44))
+        version: 9.0.1(vike@0.4.191(react-streaming@0.3.43(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.2(@types/node@18.19.44)))(vite-plugin-vercel@9.0.1)(vite@5.4.2(@types/node@18.19.44))
       vike:
         specifier: ^0.4.191
-        version: 0.4.191(react-streaming@0.3.43)(vite@5.4.2(@types/node@18.19.44))
+        version: 0.4.191(react-streaming@0.3.43(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.2(@types/node@18.19.44))
       vite:
         specifier: ^5.4.2
         version: 5.4.2(@types/node@18.19.44)
       vite-plugin-vercel:
         specifier: ^9.0.1
-        version: 9.0.1(@vite-plugin-vercel/vike@9.0.1)(encoding@0.1.13)(vike@0.4.191(react-streaming@0.3.43)(vite@5.4.2(@types/node@18.19.44)))(vite@5.4.2(@types/node@18.19.44))
+        version: 9.0.1(@vite-plugin-vercel/vike@9.0.1)(encoding@0.1.13)(vike@0.4.191(react-streaming@0.3.43(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.2(@types/node@18.19.44)))(vite@5.4.2(@types/node@18.19.44))
 
   boilerplates/vue:
     dependencies:
@@ -1369,10 +1369,10 @@ importers:
         version: 0.26.2(rollup@4.21.0)(vite@5.4.2(@types/node@18.19.44))
       vike:
         specifier: ^0.4.191
-        version: 0.4.191(react-streaming@0.3.43)(vite@5.4.2(@types/node@18.19.44))
+        version: 0.4.191(react-streaming@0.3.43(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.2(@types/node@18.19.44))
       vike-vue:
         specifier: ^0.8.2
-        version: 0.8.2(vike@0.4.191(react-streaming@0.3.43)(vite@5.4.2(@types/node@18.19.44)))(vue@3.4.38(typescript@5.5.4))
+        version: 0.8.2(vike@0.4.191(react-streaming@0.3.43(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.2(@types/node@18.19.44)))(vue@3.4.38(typescript@5.5.4))
       vite:
         specifier: ^5.4.2
         version: 5.4.2(@types/node@18.19.44)
@@ -1406,7 +1406,7 @@ importers:
         version: 6.1.0(firebase@10.13.0)
       vike:
         specifier: ^0.4.191
-        version: 0.4.191(react-streaming@0.3.43)(vite@5.4.2(@types/node@18.19.44))
+        version: 0.4.191(react-streaming@0.3.43(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.2(@types/node@18.19.44))
       vite:
         specifier: ^5.4.2
         version: 5.4.2(@types/node@18.19.44)
@@ -1428,7 +1428,7 @@ importers:
         version: 18.19.44
       vike:
         specifier: ^0.4.191
-        version: 0.4.191(react-streaming@0.3.43)(vite@5.4.2(@types/node@18.19.44))
+        version: 0.4.191(react-streaming@0.3.43(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.2(@types/node@18.19.44))
       vite:
         specifier: ^5.4.2
         version: 5.4.2(@types/node@18.19.44)
@@ -1606,6 +1606,9 @@ importers:
       which:
         specifier: ^4.0.0
         version: 4.0.0
+      yaml:
+        specifier: ^2.5.0
+        version: 2.5.0
 
   packages/create-bati:
     dependencies:
@@ -1777,10 +1780,10 @@ importers:
         version: 5.5.4
       vike:
         specifier: ^0.4.191
-        version: 0.4.191(react-streaming@0.3.43)(vite@5.4.2(@types/node@22.4.1))
+        version: 0.4.191(react-streaming@0.3.43(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.2(@types/node@22.4.1))
       vike-solid:
         specifier: ^0.7.2
-        version: 0.7.2(solid-js@1.8.21)(vike@0.4.191(react-streaming@0.3.43)(vite@5.4.2(@types/node@22.4.1)))(vite@5.4.2(@types/node@22.4.1))
+        version: 0.7.2(solid-js@1.8.21)(vike@0.4.191(react-streaming@0.3.43(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.2(@types/node@22.4.1)))(vite@5.4.2(@types/node@22.4.1))
       vite:
         specifier: ^5.4.2
         version: 5.4.2(@types/node@22.4.1)
@@ -10606,9 +10609,9 @@ snapshots:
   '@kikobeats/time-span@1.0.5':
     optional: true
 
-  '@lucia-auth/adapter-drizzle@1.1.0(drizzle-orm@0.33.0(@cloudflare/workers-types@4.20240815.0)(@prisma/client@5.18.0)(@types/better-sqlite3@7.6.11)(@types/react@18.3.3)(better-sqlite3@11.1.2)(react@18.3.1))(lucia@3.2.0)':
+  '@lucia-auth/adapter-drizzle@1.1.0(drizzle-orm@0.33.0(@cloudflare/workers-types@4.20240815.0)(@prisma/client@5.18.0(prisma@5.18.0))(@types/better-sqlite3@7.6.11)(@types/react@18.3.3)(better-sqlite3@11.1.2)(prisma@5.18.0)(react@18.3.1))(lucia@3.2.0)':
     dependencies:
-      drizzle-orm: 0.33.0(@cloudflare/workers-types@4.20240815.0)(@prisma/client@5.18.0)(@types/better-sqlite3@7.6.11)(@types/react@18.3.3)(better-sqlite3@11.1.2)(react@18.3.1)
+      drizzle-orm: 0.33.0(@cloudflare/workers-types@4.20240815.0)(@prisma/client@5.18.0(prisma@5.18.0))(@types/better-sqlite3@7.6.11)(@types/react@18.3.3)(better-sqlite3@11.1.2)(prisma@5.18.0)(react@18.3.1)
       lucia: 3.2.0
 
   '@lucia-auth/adapter-sqlite@3.0.2(better-sqlite3@11.1.2)(lucia@3.2.0)':
@@ -11491,14 +11494,14 @@ snapshots:
     optionalDependencies:
       ajv: 6.12.6
 
-  '@vite-plugin-vercel/vike@9.0.1(vike@0.4.191(react-streaming@0.3.43)(vite@5.4.2(@types/node@18.19.44)))(vite-plugin-vercel@9.0.1)(vite@5.4.2(@types/node@18.19.44))':
+  '@vite-plugin-vercel/vike@9.0.1(vike@0.4.191(react-streaming@0.3.43(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.2(@types/node@18.19.44)))(vite-plugin-vercel@9.0.1)(vite@5.4.2(@types/node@18.19.44))':
     dependencies:
       '@brillout/libassert': 0.5.8
       nanoid: 5.0.7
       qs: 6.13.0
-      vike: 0.4.191(react-streaming@0.3.43)(vite@5.4.2(@types/node@18.19.44))
+      vike: 0.4.191(react-streaming@0.3.43(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.2(@types/node@18.19.44))
       vite: 5.4.2(@types/node@18.19.44)
-      vite-plugin-vercel: 9.0.1(@vite-plugin-vercel/vike@9.0.1)(encoding@0.1.13)(vike@0.4.191(react-streaming@0.3.43)(vite@5.4.2(@types/node@18.19.44)))(vite@5.4.2(@types/node@18.19.44))
+      vite-plugin-vercel: 9.0.1(@vite-plugin-vercel/vike@9.0.1)(encoding@0.1.13)(vike@0.4.191(react-streaming@0.3.43(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.2(@types/node@18.19.44)))(vite@5.4.2(@types/node@18.19.44))
 
   '@vitejs/plugin-react@4.3.1(vite@5.4.2(@types/node@18.19.44))':
     dependencies:
@@ -12474,13 +12477,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  drizzle-orm@0.33.0(@cloudflare/workers-types@4.20240815.0)(@prisma/client@5.18.0)(@types/better-sqlite3@7.6.11)(@types/react@18.3.3)(better-sqlite3@11.1.2)(react@18.3.1):
+  drizzle-orm@0.33.0(@cloudflare/workers-types@4.20240815.0)(@prisma/client@5.18.0(prisma@5.18.0))(@types/better-sqlite3@7.6.11)(@types/react@18.3.3)(better-sqlite3@11.1.2)(prisma@5.18.0)(react@18.3.1):
     optionalDependencies:
       '@cloudflare/workers-types': 4.20240815.0
       '@prisma/client': 5.18.0(prisma@5.18.0)
       '@types/better-sqlite3': 7.6.11
       '@types/react': 18.3.3
       better-sqlite3: 11.1.2
+      prisma: 5.18.0
       react: 18.3.1
 
   duplexify@4.1.3:
@@ -15994,7 +15998,7 @@ snapshots:
       - supports-color
     optional: true
 
-  telefunc@0.1.76(@babel/core@7.25.2)(@babel/parser@7.25.3)(@babel/types@7.25.2)(react-streaming@0.3.43(react@18.3.1))(react@18.3.1):
+  telefunc@0.1.76(@babel/core@7.25.2)(@babel/parser@7.25.3)(@babel/types@7.25.2)(react-streaming@0.3.43(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1):
     dependencies:
       '@brillout/import': 0.2.3
       '@brillout/json-serializer': 0.5.13
@@ -16392,9 +16396,9 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vike-cloudflare@0.0.6(vike@0.4.191(react-streaming@0.3.43)(vite@5.4.2(@types/node@18.19.44)))(vite@5.4.2(@types/node@18.19.44)):
+  vike-cloudflare@0.0.6(vike@0.4.191(react-streaming@0.3.43(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.2(@types/node@18.19.44)))(vite@5.4.2(@types/node@18.19.44)):
     dependencies:
-      vike: 0.4.191(react-streaming@0.3.43)(vite@5.4.2(@types/node@18.19.44))
+      vike: 0.4.191(react-streaming@0.3.43(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.2(@types/node@18.19.44))
       vite: 5.4.2(@types/node@18.19.44)
     optionalDependencies:
       '@hattip/adapter-cloudflare-workers': 0.0.46
@@ -16406,29 +16410,29 @@ snapshots:
       react-streaming: 0.3.43(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       vike: 0.4.191(react-streaming@0.3.43(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.2(@types/node@18.19.44))
 
-  vike-solid@0.7.2(solid-js@1.8.21)(vike@0.4.191(react-streaming@0.3.43)(vite@5.4.2(@types/node@18.19.44)))(vite@5.4.2(@types/node@18.19.44)):
+  vike-solid@0.7.2(solid-js@1.8.21)(vike@0.4.191(react-streaming@0.3.43(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.2(@types/node@18.19.44)))(vite@5.4.2(@types/node@18.19.44)):
     dependencies:
       solid-js: 1.8.21
-      vike: 0.4.191(react-streaming@0.3.43)(vite@5.4.2(@types/node@18.19.44))
+      vike: 0.4.191(react-streaming@0.3.43(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.2(@types/node@18.19.44))
       vite-plugin-solid: 2.10.2(solid-js@1.8.21)(vite@5.4.2(@types/node@18.19.44))
     transitivePeerDependencies:
       - '@testing-library/jest-dom'
       - supports-color
       - vite
 
-  vike-solid@0.7.2(solid-js@1.8.21)(vike@0.4.191(react-streaming@0.3.43)(vite@5.4.2(@types/node@22.4.1)))(vite@5.4.2(@types/node@22.4.1)):
+  vike-solid@0.7.2(solid-js@1.8.21)(vike@0.4.191(react-streaming@0.3.43(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.2(@types/node@22.4.1)))(vite@5.4.2(@types/node@22.4.1)):
     dependencies:
       solid-js: 1.8.21
-      vike: 0.4.191(react-streaming@0.3.43)(vite@5.4.2(@types/node@22.4.1))
+      vike: 0.4.191(react-streaming@0.3.43(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.2(@types/node@22.4.1))
       vite-plugin-solid: 2.10.2(solid-js@1.8.21)(vite@5.4.2(@types/node@22.4.1))
     transitivePeerDependencies:
       - '@testing-library/jest-dom'
       - supports-color
       - vite
 
-  vike-vue@0.8.2(vike@0.4.191(react-streaming@0.3.43)(vite@5.4.2(@types/node@18.19.44)))(vue@3.4.38(typescript@5.5.4)):
+  vike-vue@0.8.2(vike@0.4.191(react-streaming@0.3.43(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.2(@types/node@18.19.44)))(vue@3.4.38(typescript@5.5.4)):
     dependencies:
-      vike: 0.4.191(react-streaming@0.3.43)(vite@5.4.2(@types/node@18.19.44))
+      vike: 0.4.191(react-streaming@0.3.43(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.2(@types/node@18.19.44))
       vue: 3.4.38(typescript@5.5.4)
 
   vike@0.4.191(react-streaming@0.3.43(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.2(@types/node@18.19.44)):
@@ -16450,26 +16454,7 @@ snapshots:
     optionalDependencies:
       react-streaming: 0.3.43(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
-  vike@0.4.191(react-streaming@0.3.43)(vite@5.4.2(@types/node@18.19.44)):
-    dependencies:
-      '@brillout/import': 0.2.3
-      '@brillout/json-serializer': 0.5.13
-      '@brillout/picocolors': 1.0.14
-      '@brillout/require-shim': 0.1.2
-      '@brillout/vite-plugin-server-entry': 0.4.8
-      acorn: 8.12.1
-      cac: 6.7.14
-      es-module-lexer: 1.5.4
-      esbuild: 0.23.1
-      fast-glob: 3.3.2
-      semver: 7.6.3
-      sirv: 2.0.4
-      source-map-support: 0.5.21
-      vite: 5.4.2(@types/node@18.19.44)
-    optionalDependencies:
-      react-streaming: 0.3.43(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-
-  vike@0.4.191(react-streaming@0.3.43)(vite@5.4.2(@types/node@22.4.1)):
+  vike@0.4.191(react-streaming@0.3.43(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.2(@types/node@22.4.1)):
     dependencies:
       '@brillout/import': 0.2.3
       '@brillout/json-serializer': 0.5.13
@@ -16544,7 +16529,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-vercel@9.0.1(@vite-plugin-vercel/vike@9.0.1)(encoding@0.1.13)(vike@0.4.191(react-streaming@0.3.43)(vite@5.4.2(@types/node@18.19.44)))(vite@5.4.2(@types/node@18.19.44)):
+  vite-plugin-vercel@9.0.1(@vite-plugin-vercel/vike@9.0.1)(encoding@0.1.13)(vike@0.4.191(react-streaming@0.3.43(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.2(@types/node@18.19.44)))(vite@5.4.2(@types/node@18.19.44)):
     dependencies:
       '@brillout/libassert': 0.5.8
       '@manypkg/find-root': 2.2.3
@@ -16557,8 +16542,8 @@ snapshots:
       vite: 5.4.2(@types/node@18.19.44)
       zod: 3.23.8
     optionalDependencies:
-      '@vite-plugin-vercel/vike': 9.0.1(vike@0.4.191(react-streaming@0.3.43)(vite@5.4.2(@types/node@18.19.44)))(vite-plugin-vercel@9.0.1)(vite@5.4.2(@types/node@18.19.44))
-      vike: 0.4.191(react-streaming@0.3.43)(vite@5.4.2(@types/node@18.19.44))
+      '@vite-plugin-vercel/vike': 9.0.1(vike@0.4.191(react-streaming@0.3.43(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.2(@types/node@18.19.44)))(vite-plugin-vercel@9.0.1)(vite@5.4.2(@types/node@18.19.44))
+      vike: 0.4.191(react-streaming@0.3.43(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.2(@types/node@18.19.44))
     transitivePeerDependencies:
       - encoding
       - supports-color


### PR DESCRIPTION
New `loadYaml` util to parse existing YAML documents. This function uses [yaml](https://www.npmjs.com/package/yaml), and returns a [Document](https://eemeli.org/yaml/#parsing-documents).

#### Usage example
```ts
import { loadYaml, type TransformerProps } from "@batijs/core";

export default async function getYaml(props: TransformerProps) {
  const document = await loadYaml(props);

  // Add a node to the document
  document.add(document.createNode({ something: true }));

  // You can return the document directly
  return document;
  // Or if you want to customize `toString` options
  return document.toString({ ... });
}
```