### PR TITLE
feat: support for !important files

### DIFF
--- a/boilerplates/README.md
+++ b/boilerplates/README.md
@@ -1,6 +1,20 @@
 > [!TIP]
 > `BATI` is a global available during the templating phase, which is a `Set` containing all chosen _features_
 
+### Special file names
+
+#### `$.*\.ts`
+File names encapsulated between `$` and `.ts`, like `$README.md.ts`, are process through callback, which let one manipulate destination file.
+Take a look at [boilerplates/shared/files/$README.md.ts](https://github.com/vikejs/bati/blob/main/boilerplates/shared/files/%24README.md.ts) for example.
+
+#### `!.*`
+File names starting with a `!` will take precedence over any other file for the same destination.
+The priority order is as follows (from lesser to higher priority):
+- non `!` files
+- `!` files
+- `$` files
+- `!$` files
+
 ### Syntax
 
 Bati uses specific syntaxes to generate its boilerplates.

--- a/packages/build/src/index.ts
+++ b/packages/build/src/index.ts
@@ -1,16 +1,17 @@
 import { existsSync } from "node:fs";
-import { mkdir, opendir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, opendir, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
-import { formatCode, transformAndFormat, type Transformer, type VikeMeta, type YAMLDocument } from "@batijs/core";
-import { mergeDts } from "./merge-dts.js";
-import { queue } from "./queue.js";
+import { type VikeMeta } from "@batijs/core";
+import type { FileOperation, OperationReport } from "./operations/common.js";
+import { executeOperationFile } from "./operations/file.js";
+import { executeOperationTransform } from "./operations/transform.js";
+import { OperationsRearranger } from "./operations/rearranger.js";
 
 const reIgnoreFile = /^(chunk-|asset-|#)/gi;
-const isWin = process.platform === "win32";
 
 function toDist(filepath: string, source: string, dist: string) {
   const split = filepath.split(path.sep);
-  split[split.length - 1] = split[split.length - 1].replace(/^\$\$?(.*)\.[tj]sx?$/, "$1");
+  split[split.length - 1] = split[split.length - 1].replace(/^\$\$?(.*)\.[tj]sx?$/, "$1").replace(/^!(.*)$/, "$1");
   return split.join(path.sep).replace(source, dist);
 }
 
@@ -22,6 +23,19 @@ async function safeWriteFile(destination: string, content: string) {
   await writeFile(destination, content, { encoding: "utf-8" });
 }
 
+async function safeRmFile(destination: string) {
+  try {
+    await rm(destination, {
+      force: true,
+      maxRetries: 3,
+      recursive: false,
+      retryDelay: 150,
+    });
+  } catch {
+    console.warn(`Failed to remove unecessary file: ${destination}`);
+  }
+}
+
 export async function* walk(dir: string): AsyncGenerator<string> {
   if (!existsSync(dir)) return;
   for await (const d of await opendir(dir)) {
@@ -30,49 +44,6 @@ export async function* walk(dir: string): AsyncGenerator<string> {
       yield* walk(entry);
     } else if (d.isFile()) yield entry;
   }
-}
-
-async function transformFileAfterExec(filepath: string, fileContent: unknown): Promise<string | null> {
-  if (fileContent === undefined || fileContent === null) return null;
-  const parsed = path.parse(filepath);
-  const toTest = [parsed.base, parsed.ext, parsed.name].filter(Boolean);
-
-  for (const ext of toTest) {
-    switch (ext) {
-      case ".ts":
-      case ".js":
-      case ".tsx":
-      case ".jsx":
-        return formatCode(fileContent as string, {
-          filepath,
-        });
-      case ".env":
-      case ".env.local":
-      case ".env.development":
-      case ".env.development.local":
-      case ".env.test":
-      case ".env.test.local":
-      case ".env.production":
-      case ".env.production.local":
-      case ".html":
-      case ".md":
-        return fileContent as string;
-      case ".json":
-        return JSON.stringify(fileContent, null, 2);
-      case ".yml":
-      case ".yaml":
-        if (typeof fileContent === "string") return fileContent;
-        return (fileContent as YAMLDocument).toString();
-    }
-  }
-  throw new Error(`Unsupported file extension ${parsed.base} (${filepath})`);
-}
-
-async function importTransformer(p: string) {
-  const importFile = isWin ? "file://" + p : p;
-  const f = await import(importFile);
-
-  return f.default as Transformer;
 }
 
 function importToPotentialTargets(imp: string) {
@@ -95,12 +66,8 @@ function importToPotentialTargets(imp: string) {
 
 export default async function main(options: { source: string | string[]; dist: string }, meta: VikeMeta) {
   const sources = Array.isArray(options.source) ? options.source : [options.source];
-  const targets = new Set<string>();
   const allImports = new Set<string>();
-  const includeIfImported = new Map<string, () => Promise<void>>();
-
-  const priorityQ = queue();
-  const transformAndWriteQ = queue();
+  const filesContainingIncludeIfImported = new Set<string>();
 
   function updateAllImports(target: string, imports?: Set<string>) {
     if (!imports) return;
@@ -115,23 +82,7 @@ export default async function main(options: { source: string | string[]; dist: s
     }
   }
 
-  async function triggerPendingTargets(target: string, imports?: Set<string>) {
-    if (!imports) return;
-
-    for (const imp of imports.values()) {
-      const importTarget = path.resolve(path.dirname(target), imp);
-      const importTargets = importToPotentialTargets(importTarget);
-
-      for (const imp2 of importTargets) {
-        if (includeIfImported.has(imp2)) {
-          const fn = includeIfImported.get(imp2)!;
-          includeIfImported.delete(imp2);
-          await fn();
-          break;
-        }
-      }
-    }
-  }
+  const rearranger = new OperationsRearranger();
 
   for (const source of sources) {
     for await (const p of walk(source)) {
@@ -145,72 +96,64 @@ export default async function main(options: { source: string | string[]; dist: s
           `Typescript file needs to be compiled before it can be executed: '${p}'.
 Please report this issue to https://github.com/vikejs/bati`,
         );
-      } else if (parsed.name.startsWith("$") && parsed.ext.match(/\.jsx?$/)) {
-        transformAndWriteQ.add(async () => {
-          const transformer = await importTransformer(p);
-
-          const rf = () => {
-            return readFile(target, { encoding: "utf-8" });
-          };
-
-          const fileContent = await transformFileAfterExec(
-            target,
-            await transformer({
-              readfile: targets.has(target) ? rf : undefined,
-              meta,
-              source,
-              target,
-            }),
-          );
-
-          if (fileContent !== null) {
-            await safeWriteFile(target, fileContent);
-            targets.add(target);
-          }
+      } else if ((parsed.name.startsWith("!$") || parsed.name.startsWith("$")) && parsed.ext.match(/\.jsx?$/)) {
+        rearranger.addFile({
+          source,
+          sourceAbsolute: p,
+          destination: target,
+          destinationAbsolute: targetAbsolute,
+          kind: "transform",
+          parsed,
+          important: parsed.name.startsWith("!"),
         });
       } else {
-        priorityQ.add(async () => {
-          const code = await readFile(p, { encoding: "utf-8" });
-          const filepath = path.relative(source, p);
-
-          const result = await transformAndFormat(code, meta, {
-            filepath,
-          });
-
-          let fileContent = result.code;
-
-          if (p.endsWith(".d.ts") && targets.has(target)) {
-            // Merging .d.ts files here
-            fileContent = await mergeDts({
-              fileContent,
-              target,
-              meta,
-              filepath,
-            });
-          }
-
-          if (fileContent) {
-            updateAllImports(targetAbsolute, result.context?.imports);
-            if (!result.context?.flags.has("include-if-imported") || allImports.has(targetAbsolute)) {
-              await safeWriteFile(target, fileContent.trimStart());
-              await triggerPendingTargets(targetAbsolute, result.context?.imports);
-            } else {
-              includeIfImported.set(targetAbsolute, () => safeWriteFile(target, fileContent.trimStart()));
-            }
-            targets.add(target);
-          }
+        rearranger.addFile({
+          source,
+          sourceAbsolute: p,
+          destination: target,
+          destinationAbsolute: targetAbsolute,
+          kind: "file",
+          parsed,
+          important: parsed.name.startsWith("!"),
         });
       }
     }
   }
 
-  await priorityQ.run();
-  await transformAndWriteQ.run();
+  let previousOp: (FileOperation & OperationReport) | undefined = undefined;
+  for (const op of rearranger.compute()) {
+    if (previousOp?.destination !== op.destination) {
+      previousOp = undefined;
+    }
+    let report: OperationReport = {};
+    if (op.kind === "file") {
+      report = await executeOperationFile(op, {
+        meta,
+        previousOperationSameDestination: previousOp,
+      });
 
-  // Ensure all pending files are copied if necessary
-  for (const target of includeIfImported.keys()) {
-    if (allImports.has(target)) {
-      await includeIfImported.get(target)!();
+      updateAllImports(op.destinationAbsolute, report.context?.imports);
+    } else if (op.kind === "transform") {
+      report = await executeOperationTransform(op, {
+        meta,
+        previousOperationSameDestination: previousOp,
+      });
+    }
+
+    if (report.content) {
+      await safeWriteFile(op.destination, report.content.trimStart());
+    }
+
+    previousOp = {
+      ...op,
+      ...report,
+    };
+  }
+
+  // Remove "include-if-imported" files if they are not imported by any other file
+  for (const target of filesContainingIncludeIfImported) {
+    if (!allImports.has(target)) {
+      await safeRmFile(target);
     }
   }
 }

--- a/packages/build/src/operations/common.ts
+++ b/packages/build/src/operations/common.ts
@@ -1,0 +1,17 @@
+import type { ParsedPath } from "node:path";
+import type { FileContext } from "@batijs/core";
+
+export interface FileOperation {
+  source: string;
+  sourceAbsolute: string;
+  destination: string;
+  destinationAbsolute: string;
+  parsed: ParsedPath;
+  kind: "file" | "transform";
+  important?: boolean;
+}
+
+export interface OperationReport {
+  context?: FileContext;
+  content?: string;
+}

--- a/packages/build/src/operations/file.ts
+++ b/packages/build/src/operations/file.ts
@@ -1,0 +1,38 @@
+import type { FileOperation, OperationReport } from "./common.js";
+import type { VikeMeta } from "@batijs/core";
+import { transformAndFormat } from "@batijs/core";
+import { readFile } from "node:fs/promises";
+import { relative } from "node:path";
+import { mergeDts } from "./merge-dts.js";
+
+export async function executeOperationFile(
+  op: FileOperation,
+  {
+    meta,
+    previousOperationSameDestination,
+  }: { meta: VikeMeta; previousOperationSameDestination?: FileOperation & OperationReport },
+): Promise<OperationReport> {
+  const code = await readFile(op.sourceAbsolute, { encoding: "utf-8" });
+  const filepath = relative(op.source, op.sourceAbsolute);
+
+  const result = await transformAndFormat(code, meta, {
+    filepath,
+  });
+
+  let fileContent = result.code;
+
+  if (op.sourceAbsolute.endsWith(".d.ts") && previousOperationSameDestination?.content) {
+    // Merging .d.ts files here
+    fileContent = await mergeDts({
+      fileContent,
+      previousContent: previousOperationSameDestination.content,
+      meta,
+      filepath,
+    });
+  }
+
+  return {
+    context: result.context,
+    content: fileContent ? fileContent.trimStart() : undefined,
+  };
+}

--- a/packages/build/src/operations/merge-dts.ts
+++ b/packages/build/src/operations/merge-dts.ts
@@ -1,4 +1,3 @@
-import { readFile } from "node:fs/promises";
 import { parseModule, transformAndFormat, type VikeMeta } from "@batijs/core";
 
 interface Node {
@@ -10,19 +9,17 @@ interface RootNode extends Node {
 }
 
 export async function mergeDts({
-  target,
   fileContent,
+  previousContent,
   filepath,
   meta,
 }: {
-  target: string;
   filepath: string;
   fileContent: string;
+  previousContent: string;
   meta: VikeMeta;
 }) {
-  const previousCode = await readFile(target, { encoding: "utf-8" });
-
-  const previousAst = parseModule(previousCode);
+  const previousAst = parseModule(previousContent);
   const currentAst = parseModule(fileContent);
 
   // Merge imports

--- a/packages/build/src/operations/rearranger.ts
+++ b/packages/build/src/operations/rearranger.ts
@@ -27,7 +27,7 @@ Please report this issue to https://github.com/vikejs/bati`);
         if (op.kind === "file" && !op.important) return 1;
         if (op.kind === "file" && op.important) return 2;
         if (op.kind === "transform" && !op.important) return 3;
-        if (op.kind === "transform" && !op.important) return 4;
+        if (op.kind === "transform" && op.important) return 4;
         return 0;
       });
 

--- a/packages/build/src/operations/rearranger.ts
+++ b/packages/build/src/operations/rearranger.ts
@@ -28,7 +28,8 @@ Please report this issue to https://github.com/vikejs/bati`);
         if (op.kind === "file" && op.important) return 2;
         if (op.kind === "transform" && !op.important) return 3;
         if (op.kind === "transform" && op.important) return 4;
-        return 0;
+
+        throw new Error("Unhandled OperationsRearranger.compute orderBy case");
       });
 
       // Keep only the last occurence of { kind: "file" }, unless it's a .d.ts file

--- a/packages/build/src/operations/rearranger.ts
+++ b/packages/build/src/operations/rearranger.ts
@@ -1,0 +1,48 @@
+import type { FileOperation } from "./common.js";
+import { orderBy } from "../utils.js";
+
+export class OperationsRearranger {
+  private files: Map<string, FileOperation[]>;
+
+  constructor() {
+    this.files = new Map();
+  }
+
+  addFile(file: FileOperation): void {
+    if (!this.files.has(file.destination)) {
+      this.files.set(file.destination, []);
+    }
+    this.files.get(file.destination)!.push(file);
+  }
+
+  *compute() {
+    for (const file of this.files.values()) {
+      if (file.filter((op) => op.important).length >= 2) {
+        throw new Error(`Error while trying to generate file: '${file[0].destination}'.
+Multiple important file is not yet supported.
+Please report this issue to https://github.com/vikejs/bati`);
+      }
+
+      const newOrder = orderBy(file, (op) => {
+        if (op.kind === "file" && !op.important) return 1;
+        if (op.kind === "file" && op.important) return 2;
+        if (op.kind === "transform" && !op.important) return 3;
+        if (op.kind === "transform" && !op.important) return 4;
+        return 0;
+      });
+
+      // Keep only the last occurence of { kind: "file" }, unless it's a .d.ts file
+      if (file[0].sourceAbsolute.endsWith(".d.ts")) {
+        yield* newOrder.filter((op) => op.kind === "file");
+      } else {
+        const input = newOrder.filter((op) => op.kind === "file").at(-1);
+
+        if (input) {
+          yield input;
+        }
+      }
+
+      yield* newOrder.filter((op) => op.kind !== "file");
+    }
+  }
+}

--- a/packages/build/src/operations/transform.ts
+++ b/packages/build/src/operations/transform.ts
@@ -1,0 +1,75 @@
+import { parse } from "path";
+import type { FileOperation, OperationReport } from "./common.js";
+import type { Transformer, VikeMeta, YAMLDocument } from "@batijs/core";
+import { formatCode } from "@batijs/core";
+
+const isWin = process.platform === "win32";
+
+async function transformFileAfterExec(filepath: string, fileContent: unknown): Promise<string | null> {
+  if (fileContent === undefined || fileContent === null) return null;
+  const parsed = parse(filepath);
+  const toTest = [parsed.base, parsed.ext, parsed.name].filter(Boolean);
+
+  for (const ext of toTest) {
+    switch (ext) {
+      case ".ts":
+      case ".js":
+      case ".tsx":
+      case ".jsx":
+        return formatCode(fileContent as string, {
+          filepath,
+        });
+      case ".env":
+      case ".env.local":
+      case ".env.development":
+      case ".env.development.local":
+      case ".env.test":
+      case ".env.test.local":
+      case ".env.production":
+      case ".env.production.local":
+      case ".html":
+      case ".md":
+        return fileContent as string;
+      case ".json":
+        return JSON.stringify(fileContent, null, 2);
+      case ".yml":
+      case ".yaml":
+        if (typeof fileContent === "string") return fileContent;
+        return (fileContent as YAMLDocument).toString();
+    }
+  }
+  throw new Error(`Unsupported file extension ${parsed.base} (${filepath})`);
+}
+
+async function importTransformer(p: string) {
+  const importFile = isWin ? "file://" + p : p;
+  const f = await import(importFile);
+
+  return f.default as Transformer;
+}
+
+export async function executeOperationTransform(
+  op: FileOperation,
+  {
+    meta,
+    previousOperationSameDestination,
+  }: { meta: VikeMeta; previousOperationSameDestination?: FileOperation & OperationReport },
+): Promise<OperationReport> {
+  const transformer = await importTransformer(op.sourceAbsolute);
+
+  const previousContent = previousOperationSameDestination?.content;
+
+  const fileContent = await transformFileAfterExec(
+    op.destination,
+    await transformer({
+      readfile: previousContent ? () => previousContent : undefined,
+      meta,
+      source: op.source,
+      target: op.destination,
+    }),
+  );
+
+  return {
+    content: fileContent !== null ? fileContent : undefined,
+  };
+}

--- a/packages/build/src/utils.ts
+++ b/packages/build/src/utils.ts
@@ -1,0 +1,10 @@
+export function orderBy<T, U>(array: T[], getter: (item: T) => U): T[] {
+  return array.slice().sort((a, b) => {
+    const valueA = getter(a);
+    const valueB = getter(b);
+
+    if (valueA < valueB) return -1;
+    if (valueA > valueB) return 1;
+    return 0;
+  });
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,4 @@
-export { transformAndFormat } from "./parse.js";
+export { transformAndFormat, type FileContext } from "./parse.js";
 export { formatCode } from "./format.js";
 export * from "./loaders.js";
 export * from "./magicast.js";

--- a/packages/core/src/parse.ts
+++ b/packages/core/src/parse.ts
@@ -36,3 +36,5 @@ export async function transformAndFormat(code: string, meta: VikeMeta, options: 
     context,
   };
 }
+
+export type { FileContext };


### PR DESCRIPTION
File names starting with a `!` will take precedence over any other file for the same destination.
The priority order is as follows (from lesser to higher priority):
- non `!` files
- `!` files
- `$` files
- `!$` files