### PR TITLE
fix: bati cli / check if options are valid options

### DIFF
--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -214,6 +214,22 @@ async function checkArguments(args: ParsedArgs<Args>) {
   }
 }
 
+function checkFlagsExist(flags: string[]) {
+  const inValidOptions = flags.reduce((acc: string[], flag: string) => {
+    if (!Object.prototype.hasOwnProperty.call(defaultDef, flag) && !features.some((f) => f.flag === flag)) {
+      acc.push(flag);
+    }
+    return acc;
+  }, []);
+  const count = inValidOptions.length;
+  if (count) {
+    console.error(
+      `${red("⚠")} Unknown option${count > 1 ? "s" : ""} ${bold(inValidOptions.join(", "))}. Use \`--help\` to list all available options.`,
+    );
+    process.exit(5);
+  }
+}
+
 function checkRules(flags: string[]) {
   const potentialRulesMessages = execRules(flags as FeatureOrCategory[], rulesMessages);
 
@@ -340,6 +356,7 @@ async function run() {
         })
         .flat(1);
 
+      checkFlagsExist(flags);
       checkRules(flags);
 
       // `enforce: "pre"` boilerplates first, then `enforce: undefined`, then `enforce: "post"`


### PR DESCRIPTION
**Problem:**
`$ pnpm cli --lucia`

this command line will not throw an error about the not existing option `lucia`

**Fix:**
* check if command line options are in `defaultDef` (project, force, skip-git)
* check if option is an availiable feature
* return an error message with a list of all unknown options

**Example:**
```
$ pnpm cli --hono1 --lucia --sqlight
⚠ Unknown options hono1, lucia, sqlight. Use `--help` to list all available options.
 ELIFECYCLE  Command failed with exit code 5.
```
