### PR TITLE
fix: block using `--aws` without selecting one of the required Servers

### DIFF
--- a/packages/cli/rules.ts
+++ b/packages/cli/rules.ts
@@ -54,8 +54,7 @@ Choose one of them, or simply remove selected Server`,
     `${inverse(bold("Lucia"))} requires a ${inverse(bold("Database"))}, and is only compatible with ${inverse(bold("SQLite"))} or ${inverse(bold("Drizzle"))}`,
   ),
   [RulesMessage.ERROR_AWS_R_COMPAT_SERVER]: error(
-    `${inverse(bold("AWS"))} is only compatible with ${inverse(bold("Hono"))} or ${inverse(bold("HatTip"))}.
-Choose one of them, or simply remove selected Server`,
+    `${inverse(bold("AWS"))} deployment is only compatible with ${inverse(bold("Hono"))} or ${inverse(bold("HatTip"))}. Choose one of them`,
   ),
   [RulesMessage.ERROR_SHADCN_R_REACT]: error(
     `${inverse(bold("shadcn/ui"))} is only compatible with ${inverse(bold("React"))}`,

--- a/packages/cli/rules.ts
+++ b/packages/cli/rules.ts
@@ -54,7 +54,7 @@ Choose one of them, or simply remove selected Server`,
     `${inverse(bold("Lucia"))} requires a ${inverse(bold("Database"))}, and is only compatible with ${inverse(bold("SQLite"))} or ${inverse(bold("Drizzle"))}`,
   ),
   [RulesMessage.ERROR_AWS_R_COMPAT_SERVER]: error(
-    `${inverse(bold("AWS"))} deployment is only compatible with ${inverse(bold("Hono"))} or ${inverse(bold("HatTip"))}. Choose one of them`,
+    `${inverse(bold("AWS"))} deployment is only compatible with ${inverse(bold("Hono"))} or ${inverse(bold("HatTip"))}. Please pick one`,
   ),
   [RulesMessage.ERROR_SHADCN_R_REACT]: error(
     `${inverse(bold("shadcn/ui"))} is only compatible with ${inverse(bold("React"))}`,

--- a/packages/features/src/rules/rules.ts
+++ b/packages/features/src/rules/rules.ts
@@ -29,8 +29,8 @@ export default [
         return false;
       }
 
-      // If it has any other server, return the message
-      return fts.has("Server");
+      // If it has any other server or none, return the message
+      return true;
     }
 
     return false;

--- a/website/components/RulesMessages.tsx
+++ b/website/components/RulesMessages.tsx
@@ -167,7 +167,7 @@ export const rulesMessages = {
         )}
         <ul class="list-custom list-dot">
           <li>
-            Pick a server: <span class="font-bold">Hono</span> or <span class="font-bold">HatTip</span>
+            Compatible servers: <span class="font-bold">Hono</span>, <span class="font-bold">HatTip</span>
           </li>
         </ul>
       </span>

--- a/website/components/RulesMessages.tsx
+++ b/website/components/RulesMessages.tsx
@@ -150,15 +150,24 @@ export const rulesMessages = {
   [RulesMessage.ERROR_AWS_R_COMPAT_SERVER]: error(() => {
     const { selectedFeatures } = useContext(StoreContext);
 
-    const selectedServer = createMemo(() => selectedFeatures().filter((f) => f.category === "Server")?.[0].label);
+    const selectedServer = createMemo(() => selectedFeatures().filter((f) => f.category === "Server")?.[0]?.label);
 
     return (
       <span class="inline-block">
-        <span class="font-bold">AWS</span> is not compatible with <span class="font-bold">{selectedServer()}</span>.
+        {selectedServer() && (
+          <>
+            <span class="font-bold">AWS</span> deployment is not compatible with{" "}
+            <span class="font-bold">{selectedServer()}</span>.
+          </>
+        )}
+        {!selectedServer() && (
+          <>
+            <span class="font-bold">AWS</span> deployment requires a compatible server.
+          </>
+        )}
         <ul class="list-custom list-dot">
           <li>
-            Either pick a <span class="font-bold">Hono</span> or <span class="font-bold">HatTip</span>, or unselect{" "}
-            <span class="font-bold">{selectedServer()}</span>
+            Pick a server: <span class="font-bold">Hono</span> or <span class="font-bold">HatTip</span>
           </li>
         </ul>
       </span>


### PR DESCRIPTION
* bati cli: block using `--aws` without selecting one of the required Servers
* website: optimize text to force selecting one of the possible servers