### PR TITLE
Fix: Add .gitignore file to React boilerplates

### DIFF
--- a/boilerplates/react/.gitignore
+++ b/boilerplates/react/.gitignore
@@ -1,0 +1,2 @@
+dist/
+node_modules/


### PR DESCRIPTION
Currently, when you scaffold a Vike React app using Bati, you get over 3 thousand diffs in Git history (please see screenshot), this is because there isn't a `.gitignore` file in the React Boilerplates.  I'm adding a `.gitignore` file in the React Boilerplates to rectify this.  By the way, this is a wonderful project, thank you so much.

![Bati_PR](https://github.com/user-attachments/assets/d066307b-178f-41d0-ba43-ae66d23acc5e)

