### PR TITLE
Updates `hono-entry.node.ts` to serve static files from public directory

### DIFF
--- a/boilerplates/hono/files/hono-entry.node.ts
+++ b/boilerplates/hono/files/hono-entry.node.ts
@@ -12,7 +12,7 @@ const nodeApp = new Hono();
 nodeApp.use(compress());
 
 nodeApp.use(
-  "/assets/*",
+  "/*",
   serveStatic({
     root: `./dist/client/`,
   }),


### PR DESCRIPTION
Fixes #451 

As mentioned in the issue, project with Hono doesn't serve static files that they put to the `public/` directory.
After some investigation, turns out that in `hono-entry.node.ts` there are these lines:

```tsx
nodeApp.use(
  '/assets/*',
  serveStatic({
    root: './dist/client/',
  }),
);
```

Because of these lines, Vike app files are served correctly, because they are in `./dist/client/assets/` directory, but if I had file under `public/logo.svg`, during build it will be copied to `./dist/client/logo.svg` and Hono lacks routing rule for that.

This PR changes pattern from `assets/*` to just `/*`, it matches both cases, so that all files from the public directory start serving normally as well as `/assets` dir is resolved