### PR TITLE
Update React tsconfigs to use new JSX transform

### DIFF
--- a/boilerplates/eslint/files/eslint.config.js
+++ b/boilerplates/eslint/files/eslint.config.js
@@ -2,7 +2,7 @@
 
 import eslint from "@eslint/js";
 import prettier from "eslint-plugin-prettier/recommended";
-import react from "eslint-plugin-react/configs/recommended.js";
+import react from "eslint-plugin-react";
 import solid from "eslint-plugin-solid/configs/typescript";
 import pluginVue from "eslint-plugin-vue";
 import globals from "globals";
@@ -64,9 +64,9 @@ export default tseslint.config(
   //# BATI.has("react")
   {
     files: ["**/*.{js,mjs,cjs,jsx,mjsx,ts,tsx,mtsx}"],
-    ...react,
+    ...react.configs.flat.recommended,
     languageOptions: {
-      ...react.languageOptions,
+      ...react.configs.flat.recommended.languageOptions,
       globals: {
         ...globals.serviceworker,
         ...globals.browser,
@@ -79,6 +79,8 @@ export default tseslint.config(
       },
     },
   },
+  //# BATI.has("react")
+  react.configs.flat["jsx-runtime"],
   //# BATI.has("solid")
   {
     files: ["**/*.{ts,tsx,js,jsx}"],

--- a/boilerplates/eslint/files/eslint.config.ts
+++ b/boilerplates/eslint/files/eslint.config.ts
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 import eslint from "@eslint/js";
 import prettier from "eslint-plugin-prettier/recommended";
 import react from "eslint-plugin-react";

--- a/boilerplates/mantine/files/components/Link.tsx
+++ b/boilerplates/mantine/files/components/Link.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { usePageContext } from "vike-react/usePageContext";
 import { NavLink } from "@mantine/core";
 

--- a/boilerplates/mantine/files/layouts/LayoutDefault.tsx
+++ b/boilerplates/mantine/files/layouts/LayoutDefault.tsx
@@ -1,5 +1,4 @@
 import "@mantine/core/styles.css";
-import React from "react";
 import { AppShell, Burger, Group, Image, MantineProvider } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
 import theme from "./theme.js";

--- a/boilerplates/mantine/tsconfig.json
+++ b/boilerplates/mantine/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": ["../tsconfig.base.json"],
   "compilerOptions": {
     "types": ["vite/client", "@types/node", "vike-react", "@batijs/core/types", "vite-plugin-compiled-react"],
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "jsxImportSource": "react",
     "lib": ["DOM", "DOM.Iterable", "ES2022"],
     "baseUrl": "."

--- a/boilerplates/react-firebase-auth/files/pages/login/+Page.tsx
+++ b/boilerplates/react-firebase-auth/files/pages/login/+Page.tsx
@@ -2,7 +2,7 @@ import "firebaseui/dist/firebaseui.css";
 import { startFirebaseUI } from "@batijs/firebase-auth/libs/firebaseUI";
 import { getAuth, type UserCredential } from "firebase/auth";
 import * as firebaseui from "firebaseui";
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { reload } from "vike/client/router";
 
 export default Page;

--- a/boilerplates/react-firebase-auth/tsconfig.json
+++ b/boilerplates/react-firebase-auth/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": ["../tsconfig.base.json"],
   "compilerOptions": {
     "types": ["vite/client", "@types/node", "@batijs/core/types"],
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "jsxImportSource": "react",
     "lib": ["DOM", "DOM.Iterable", "ES2022"]
   }

--- a/boilerplates/react-lucia-auth/files/pages/login/+Page.tsx
+++ b/boilerplates/react-lucia-auth/files/pages/login/+Page.tsx
@@ -1,5 +1,5 @@
 import "./style.css";
-import React, { useState } from "react";
+import { useState } from "react";
 import { navigate } from "vike/client/router";
 
 type ValidationError = { username: string | null; password: string | null; invalid?: string };

--- a/boilerplates/react-lucia-auth/tsconfig.json
+++ b/boilerplates/react-lucia-auth/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": ["../tsconfig.base.json"],
   "compilerOptions": {
     "types": ["vite/client", "@types/node", "@batijs/core/types"],
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "jsxImportSource": "react",
     "lib": ["DOM", "DOM.Iterable", "ES2022"]
   }

--- a/boilerplates/react-sentry/files/pages/sentry/+Page.tsx
+++ b/boilerplates/react-sentry/files/pages/sentry/+Page.tsx
@@ -1,8 +1,8 @@
-import React, { useEffect } from "react";
+import { useEffect, useState } from "react";
 import * as Sentry from "@sentry/react";
 
 export default function ReactSentryErrorPage() {
-  const [sentryClientStatus, setSentryClientStatus] = React.useState({
+  const [sentryClientStatus, setSentryClientStatus] = useState({
     client_not_loaded: false,
     enabled: true,
     dsn_missing: false,

--- a/boilerplates/react-sentry/tsconfig.json
+++ b/boilerplates/react-sentry/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": ["../tsconfig.base.json"],
   "compilerOptions": {
     "types": ["@batijs/core/types", "vite/client"],
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "jsxImportSource": "react",
     "lib": ["DOM", "DOM.Iterable", "ES2022"]
   }

--- a/boilerplates/react/files/$tsconfig.json.ts
+++ b/boilerplates/react/files/$tsconfig.json.ts
@@ -3,7 +3,7 @@ import { loadAsJson, type TransformerProps } from "@batijs/core";
 export default async function getTsConfig(props: TransformerProps) {
   const tsConfig = await loadAsJson(props);
 
-  tsConfig.compilerOptions.jsx = "preserve";
+  tsConfig.compilerOptions.jsx = "react-jsx";
   tsConfig.compilerOptions.jsxImportSource = "react";
   tsConfig.compilerOptions.types = [...(tsConfig.compilerOptions.types ?? []), "vike-react"];
 

--- a/boilerplates/react/files/components/Link.tsx
+++ b/boilerplates/react/files/components/Link.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { usePageContext } from "vike-react/usePageContext";
 
 export function Link({ href, children }: { href: string; children: string }) {

--- a/boilerplates/react/files/layouts/LayoutDefault.tsx
+++ b/boilerplates/react/files/layouts/LayoutDefault.tsx
@@ -3,7 +3,6 @@ import "./style.css";
 import "./tailwind.css";
 //# BATI.has("panda-css")
 import "./panda.css";
-import React from "react";
 import logoUrl from "../assets/logo.svg";
 import { Link } from "../components/Link.js";
 import { css } from "../styled-system/css";

--- a/boilerplates/react/files/pages/+Head.tsx
+++ b/boilerplates/react/files/pages/+Head.tsx
@@ -1,6 +1,5 @@
 // https://vike.dev/Head
 
-import React from "react";
 import logoUrl from "../assets/logo.svg";
 //# BATI.has("mantine")
 import { ColorSchemeScript } from "@mantine/core";

--- a/boilerplates/react/files/pages/_error/+Page.tsx
+++ b/boilerplates/react/files/pages/_error/+Page.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { usePageContext } from "vike-react/usePageContext";
 
 export default function Page() {

--- a/boilerplates/react/files/pages/index/+Page.tsx
+++ b/boilerplates/react/files/pages/index/+Page.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Counter } from "./Counter.js";
 import { css } from "../../styled-system/css";
 

--- a/boilerplates/react/files/pages/index/Counter.tsx
+++ b/boilerplates/react/files/pages/index/Counter.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { css } from "../../styled-system/css";
 
 export function Counter() {

--- a/boilerplates/react/files/pages/star-wars/@id/+Page.tsx
+++ b/boilerplates/react/files/pages/star-wars/@id/+Page.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useData } from "vike-react/useData";
 import type { Data } from "./+data.js";
 

--- a/boilerplates/react/files/pages/star-wars/index/+Page.tsx
+++ b/boilerplates/react/files/pages/star-wars/index/+Page.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useData } from "vike-react/useData";
 import type { Data } from "./+data.js";
 

--- a/boilerplates/react/files/pages/todo/+Page.tsx
+++ b/boilerplates/react/files/pages/todo/+Page.tsx
@@ -1,5 +1,4 @@
 import type { Data } from "@batijs/shared-todo/pages/todo/+data";
-import React from "react";
 import { useData } from "vike-react/useData";
 import { TodoList } from "./TodoList.js";
 

--- a/boilerplates/react/files/pages/todo/TodoList.tsx
+++ b/boilerplates/react/files/pages/todo/TodoList.tsx
@@ -2,7 +2,7 @@ import { onNewTodo } from "@batijs/telefunc/pages/todo/TodoList.telefunc";
 import { trpc } from "@batijs/trpc/trpc/client";
 import { client } from "@batijs/ts-rest/ts-rest/client";
 import { css } from "../../styled-system/css";
-import React, { useState } from "react";
+import { useState } from "react";
 
 export function TodoList({ initialTodoItems }: { initialTodoItems: { text: string }[] }) {
   const [todoItems, setTodoItems] = useState(initialTodoItems);

--- a/boilerplates/react/tsconfig.json
+++ b/boilerplates/react/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": ["../tsconfig.base.json"],
   "compilerOptions": {
     "types": ["vite/client", "@types/node", "vike-react", "@batijs/core/types", "vite-plugin-compiled-react"],
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "jsxImportSource": "react",
     "lib": ["DOM", "DOM.Iterable", "ES2022"],
     "baseUrl": "."

--- a/boilerplates/solid/files/$tsconfig.json.ts
+++ b/boilerplates/solid/files/$tsconfig.json.ts
@@ -3,7 +3,7 @@ import { loadAsJson, type TransformerProps } from "@batijs/core";
 export default async function getTsConfig(props: TransformerProps) {
   const tsConfig = await loadAsJson(props);
 
-  tsConfig.compilerOptions.jsx = "preserve";
+  tsConfig.compilerOptions.jsx = "react-jsx";
   tsConfig.compilerOptions.jsxImportSource = "solid-js";
   tsConfig.compilerOptions.types = [...(tsConfig.compilerOptions.types ?? []), "vike-solid/client"];
 

--- a/boilerplates/vue/files/$tsconfig.json.ts
+++ b/boilerplates/vue/files/$tsconfig.json.ts
@@ -3,7 +3,7 @@ import { loadAsJson, type TransformerProps } from "@batijs/core";
 export default async function getTsConfig(props: TransformerProps) {
   const tsConfig = await loadAsJson(props);
 
-  tsConfig.compilerOptions.jsx = "preserve";
+  tsConfig.compilerOptions.jsx = "react-jsx";
   tsConfig.compilerOptions.jsxImportSource = "vue";
 
   return tsConfig;

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -2,7 +2,7 @@
 
 import eslint from "@eslint/js";
 import prettier from "eslint-plugin-prettier/recommended";
-import react from "eslint-plugin-react/configs/recommended.js";
+import react from "eslint-plugin-react";
 import solid from "eslint-plugin-solid/configs/typescript";
 import pluginVue from "eslint-plugin-vue";
 import globals from "globals";
@@ -78,9 +78,9 @@ export default tseslint.config(
       "boilerplates/react/**/*.{js,mjs,cjs,jsx,mjsx,ts,tsx,mtsx}",
       "boilerplates/react-*/**/*.{js,mjs,cjs,jsx,mjsx,ts,tsx,mtsx}",
     ],
-    ...react,
+    ...react.configs.flat.recommended,
     languageOptions: {
-      ...react.languageOptions,
+      ...react.configs.flat.recommended.languageOptions,
       globals: {
         ...globals.serviceworker,
         ...globals.browser,
@@ -93,6 +93,7 @@ export default tseslint.config(
       },
     },
   },
+  react.configs.flat["jsx-runtime"],
   {
     files: ["boilerplates/react/**/*.tsx", "boilerplates/react-*/**/*.tsx"],
     rules: {

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 import eslint from "@eslint/js";
 import prettier from "eslint-plugin-prettier/recommended";
 import react from "eslint-plugin-react";

--- a/packages/core/tests/transform-ts.spec.ts
+++ b/packages/core/tests/transform-ts.spec.ts
@@ -89,12 +89,12 @@ describe("ts: if-elseif-else block", () => {
     `if (BATI.has("react")) {
     content = { ...content, jsx: "react" };
   } else if (BATI.has("solid")) {
-    content = { ...content, jsx: "preserve", jsxImportSource: "solid-js" };
+    content = { ...content, jsx: "react-jsx", jsxImportSource: "solid-js" };
   } else {
     console.log("NOTHING TO DO");
   }`,
     `content = { ...content, jsx: "react" };`,
-    `content = { ...content, jsx: "preserve", jsxImportSource: "solid-js" };`,
+    `content = { ...content, jsx: "react-jsx", jsxImportSource: "solid-js" };`,
     `console.log("NOTHING TO DO");`,
   );
 });
@@ -104,11 +104,11 @@ describe("ts: if-elseif-else statement", () => {
     `if (BATI.has("react"))
     content = { ...content, jsx: "react" };
   else if (BATI.has("solid"))
-    content = { ...content, jsx: "preserve", jsxImportSource: "solid-js" };
+    content = { ...content, jsx: "react-jsx", jsxImportSource: "solid-js" };
   else
     console.log("NOTHING TO DO");`,
     `content = { ...content, jsx: "react" };`,
-    `content = { ...content, jsx: "preserve", jsxImportSource: "solid-js" };`,
+    `content = { ...content, jsx: "react-jsx", jsxImportSource: "solid-js" };`,
     `console.log("NOTHING TO DO");`,
   );
 });


### PR DESCRIPTION
For the eslint config boilerplate:
- Use [flat configs](https://github.com/jsx-eslint/eslint-plugin-react/blob/3a035798d510feb92735af5d452e96a9c01873c3/README.md#flat-configs)
- Add jsx-runtime flat config
- Use [.ts extension](https://eslint.org/docs/latest/use/configure/configuration-files#typescript-configuration-files) for config file (the Jiti requirement is already a Vite dep)

For React tsconfigs:
- Switch JSX transform from "preserve" to newer "react-jsx" (allows developers to omit React imports in component files)
- Remove unnecessary React imports from boilerplates