### PR TITLE
fix(boilerplates/vue): import tailwind directly in js

### DIFF
--- a/boilerplates/vue/files/pages/+Head.vue
+++ b/boilerplates/vue/files/pages/+Head.vue
@@ -2,8 +2,6 @@
 
 <template>
   <link rel="icon" :href="logoUrl" />
-  <!-- BATI.has("tailwindcss") -->
-  <link rel="stylesheet" :href="tailwindCss" />
 
   <!-- BATI.has("plausible.io") -->
   <!-- See https://plausible.io/docs/plausible-script -->
@@ -14,5 +12,5 @@
 <script setup lang="ts">
 import logoUrl from "../assets/logo.svg";
 //# BATI.has("tailwindcss")
-import * as tailwindCss from "@batijs/tailwindcss/layouts/tailwind.css";
+import "@batijs/tailwindcss/layouts/tailwind.css";
 </script>


### PR DESCRIPTION
For the old one, ts complains `Type 'typeof import("*.css")' is not assignable to type 'string'.` I don't really understand the details of CSS imports, but this one seems to work fine and shuts ts up.