### PR TITLE
refactor(skills): describe the llms.txt as a documentation index

### DIFF
--- a/boilerplates/shared-agents/compose.spec.ts
+++ b/boilerplates/shared-agents/compose.spec.ts
@@ -5,7 +5,7 @@ test("renderSkillMd — frontmatter + URL-only body", () => {
   expect(renderSkillMd("react", "React", "https://react.dev/llms.txt")).toBe(
     `---
 name: "react"
-description: "React documentation — consider reading it, e.g. when using uncommon React APIs or when stuck on a React problem"
+description: "React documentation index — a compact overview of React's docs. Consider consulting it, e.g. when using uncommon React APIs or when stuck on a React problem."
 ---
 
 See https://react.dev/llms.txt
@@ -16,6 +16,12 @@ See https://react.dev/llms.txt
 test("renderSkillMd — a label starting with a vowel gets the right article", () => {
   expect(renderSkillMd("express", "Express", "https://expressjs.com/llms.txt")).toContain(
     "when stuck on an Express problem",
+  );
+});
+
+test("renderSkillMd — a label ending in s takes a bare possessive apostrophe", () => {
+  expect(renderSkillMd("edgeone", "EdgeOne Pages", "https://edgeone.ai/llms.txt")).toContain(
+    "overview of EdgeOne Pages' docs",
   );
 });
 

--- a/boilerplates/shared-agents/compose.ts
+++ b/boilerplates/shared-agents/compose.ts
@@ -21,12 +21,17 @@ export function composeSkills(isSelected: (flag: Flags) => boolean): ComposedSki
 
 export function renderSkillMd(flag: string, label: string, llms: string): string {
   // Deliberately vague: the agent should reach for the docs when it's unsure, not on every edit.
-  const description = `${label} documentation — consider reading it, e.g. when using uncommon ${label} APIs or when stuck on ${article(label)} ${label} problem`;
+  const description = `${label} documentation index — a compact overview of ${possessive(label)} docs. Consider consulting it, e.g. when using uncommon ${label} APIs or when stuck on ${article(label)} ${label} problem.`;
   return `---\nname: ${yamlString(flag)}\ndescription: ${yamlString(description)}\n---\n\nSee ${llms}\n`;
 }
 
 function article(label: string): string {
   return /^[aeiou]/i.test(label) ? "an" : "a";
+}
+
+// `Vike` → `Vike's`, but `EdgeOne Pages` → `EdgeOne Pages'` (no doubled sibilant).
+function possessive(label: string): string {
+  return /s$/i.test(label) ? `${label}'` : `${label}'s`;
 }
 
 // Double-quote and escape so the colons/brackets common in descriptions stay YAML-safe.


### PR DESCRIPTION
## What

Follow-up to #788. Reworks the generated skill description to name what the linked `llms.txt` actually is.

Before:

```md
---
name: "vike"
description: "Vike documentation — consider reading it, e.g. when using uncommon Vike APIs or when stuck on a Vike problem"
---

See https://vike.dev/llms.txt
```

After:

```md
---
name: "vike"
description: "Vike documentation index — a compact overview of Vike's docs. Consider consulting it, e.g. when using uncommon Vike APIs or when stuck on a Vike problem."
---

See https://vike.dev/llms.txt
```

## Why

An `llms.txt` is an index of a tool's documentation, not the documentation itself. Calling it "documentation" oversells what the agent gets when it follows the link — saying "documentation index — a compact overview" sets the right expectation: this is a map to navigate from, not the full reference.

## Changes

- `boilerplates/shared-agents/compose.ts` — new description template, plus a `possessive()` helper so labels ending in `s` read correctly: `EdgeOne Pages' docs` and `SolidJS' docs` rather than `EdgeOne Pages's`. This sits alongside the existing `article()` helper that picks `a`/`an`.
- `boilerplates/shared-agents/compose.spec.ts` — updated expected output, plus a case covering the possessive rule.

All 26 generated descriptions were rendered and checked; the two grammar helpers together make every label read correctly, including the awkward ones (`EdgeOne Pages`, `SolidJS`, `Express`, `Elysia`, `Oxlint`, `shadcn/ui`).

## Testing

`bun run build`, `bun run test` (6 passing in `compose.spec.ts`), `bun run lint`, and `bun run check-types` (61 projects) all pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wx9RcQjRdeFsTRdjtoF6gk)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated skill descriptions to present a concise documentation overview.
  - Clarified that skill documentation should be consulted for uncommon APIs and unresolved issues.
  - Improved possessive label formatting, including correct handling for labels ending in “s”.

- **Tests**
  - Added coverage to verify consistent possessive formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->