### PR TITLE
chore: use Vike as scaffolded commit author

### DIFF
--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -527,8 +527,8 @@ function gitInit(cwd: string) {
     execSync(
       [
         "git",
-        '-c user.name="Bati"',
-        '-c user.email="no-reply@batijs.dev"',
+        '-c user.name="Vike"',
+        '-c user.email="no-reply@vike.dev"',
         "commit",
         "--no-gpg-sign",
         '--message="scaffold Vike app with Bati"',


### PR DESCRIPTION
Changes the author of the initial commit created by `gitInit()` in `packages/cli/index.ts` when scaffolding a new app.

- Before: `Bati <no-reply@batijs.dev>`
- After: `Vike <no-reply@vike.dev>`

The commit message itself (`scaffold Vike app with Bati`) is unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TmqiAZZAABaDst6wAZpUxf)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Git repositories initialized by the CLI now use the correct default author identity: `Vike <no-reply@vike.dev>`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->