### PR TITLE
feat(pnpm): set dangerouslyAllowAllBuilds instead of per-package allowBuilds

### DIFF
--- a/boilerplates/pnpm/files/$pnpm-workspace.yaml.ts
+++ b/boilerplates/pnpm/files/$pnpm-workspace.yaml.ts
@@ -1,45 +1,12 @@
-import { loadYaml, type TransformerProps, YAMLMap } from "@batijs/core";
-
-const dependenciesApproveBuild: Record<string, boolean | string[]> = {
-  "@biomejs/biome": true,
-  "@sentry/cli": true,
-  "@tailwindcss/oxide": true,
-  "better-sqlite3": true,
-  esbuild: true,
-  sharp: true,
-  workerd: true,
-  tsx: ["esbuild"],
-};
-
-function intersect<T>(a: T[], b: T[]) {
-  return a.filter((x) => b.includes(x));
-}
+import { loadYaml, type TransformerProps } from "@batijs/core";
 
 export default async function getPnpmWorkspace(props: TransformerProps): Promise<unknown> {
-  const deps = [
-    ...Object.keys(props.packageJson.dependencies ?? {}),
-    ...Object.keys(props.packageJson.devDependencies ?? {}),
-  ];
-  const intersection = intersect(Object.keys(dependenciesApproveBuild), deps);
-  if (intersection.length === 0) return;
-
   const pnpmWorkspace = await loadYaml(props, { fallbackEmpty: true });
-  let allowBuilds = pnpmWorkspace.get("allowBuilds", true) as YAMLMap | undefined;
 
-  if (!allowBuilds) {
-    allowBuilds = new YAMLMap();
-    pnpmWorkspace.set("allowBuilds", allowBuilds);
-  }
-
-  for (const pack of intersection) {
-    if (dependenciesApproveBuild[pack] === true) {
-      allowBuilds.set(pack, true);
-    } else if (Array.isArray(dependenciesApproveBuild[pack])) {
-      for (const pack2 of dependenciesApproveBuild[pack]) {
-        allowBuilds.set(pack2, true);
-      }
-    }
-  }
+  // Let pnpm run the build scripts of all dependencies, so installs never hang on
+  // interactive approval or silently skip required postinstall steps.
+  // https://pnpm.io/settings/build#dangerouslyallowallbuilds
+  pnpmWorkspace.set("dangerouslyAllowAllBuilds", true);
 
   return pnpmWorkspace;
 }


### PR DESCRIPTION
## Description

For pnpm users, the generated `pnpm-workspace.yaml` now sets [`dangerouslyAllowAllBuilds: true`](https://pnpm.io/settings/build#dangerouslyallowallbuilds) so pnpm runs the build scripts of all dependencies during install.

This replaces the manually maintained `dependenciesApproveBuild` map in `boilerplates/pnpm/files/$pnpm-workspace.yaml.ts`, which had to be kept in sync with every direct and transitive dependency shipping a postinstall script — any miss meant an interactive approval prompt or a silently skipped build in freshly scaffolded apps.

Since the setting applies regardless of the selected features, the file is now always generated for pnpm users (previously it was only emitted when the dependency list intersected the allowlist).

## Validation

- Ran the CLI with a pnpm user agent (`--react --hono`): the generated `pnpm-workspace.yaml` contains exactly `dangerouslyAllowAllBuilds: true`, and `pnpm install` (pnpm 10.33) succeeds with esbuild's postinstall running automatically — no approval prompt, no "Ignored build scripts" warning.
- Ran the CLI without a pnpm user agent: no `pnpm-workspace.yaml` is generated, as before.
- `bun run build`, `bun run test`, `bun run check-types`, `bun run lint` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RisVvvRs9isNMhmFqyo1i1

---
_Generated by [Claude Code](https://claude.ai/code/session_01RisVvvRs9isNMhmFqyo1i1)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Dependency build scripts are now enabled automatically across the pnpm workspace.
  * Removed selective approval rules for dependency build scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->