### PR TITLE
fix: repair scaffolds broken by better-auth 1.7 and oxlint 1.80

### DIFF
--- a/boilerplates/better-auth/files/database/drizzle/schema/auth.ts
+++ b/boilerplates/better-auth/files/database/drizzle/schema/auth.ts
@@ -1,9 +1,9 @@
 /* $$.keepFileIfImported */
-import { boolean, pgTable, text as pgText, timestamp } from "drizzle-orm/pg-core";
-import { integer, sqliteTable, text as sqliteText } from "drizzle-orm/sqlite-core";
+import { boolean, pgTable, text as pgText, timestamp, uniqueIndex as pgUniqueIndex } from "drizzle-orm/pg-core";
+import { integer, sqliteTable, text as sqliteText, uniqueIndex as sqliteUniqueIndex } from "drizzle-orm/sqlite-core";
 
 // Better Auth's tables, owned by Drizzle so its migrations create them.
-// Regenerate with `npx @better-auth/cli generate` if you customize the Better Auth config.
+// Regenerate with `npx auth generate` if you customize the Better Auth config.
 // Column names are snake_case to match Better Auth's Drizzle adapter defaults.
 
 export const user = $$.BATI.has("postgres")
@@ -48,37 +48,49 @@ export const session = $$.BATI.has("postgres")
       userId: sqliteText("user_id").notNull(),
     });
 
+// Since Better Auth 1.7 account identity is scoped by `issuer`: the column is required and
+// (issuer, accountId) must be unique. https://better-auth.com/docs/guides/1-7-upgrade-guide
 export const account = $$.BATI.has("postgres")
-  ? pgTable("account", {
-      id: pgText("id").primaryKey(),
-      accountId: pgText("account_id").notNull(),
-      providerId: pgText("provider_id").notNull(),
-      userId: pgText("user_id").notNull(),
-      accessToken: pgText("access_token"),
-      refreshToken: pgText("refresh_token"),
-      idToken: pgText("id_token"),
-      accessTokenExpiresAt: timestamp("access_token_expires_at"),
-      refreshTokenExpiresAt: timestamp("refresh_token_expires_at"),
-      scope: pgText("scope"),
-      password: pgText("password"),
-      createdAt: timestamp("created_at").notNull(),
-      updatedAt: timestamp("updated_at").notNull(),
-    })
-  : sqliteTable("account", {
-      id: sqliteText("id").primaryKey(),
-      accountId: sqliteText("account_id").notNull(),
-      providerId: sqliteText("provider_id").notNull(),
-      userId: sqliteText("user_id").notNull(),
-      accessToken: sqliteText("access_token"),
-      refreshToken: sqliteText("refresh_token"),
-      idToken: sqliteText("id_token"),
-      accessTokenExpiresAt: integer("access_token_expires_at", { mode: "timestamp_ms" }),
-      refreshTokenExpiresAt: integer("refresh_token_expires_at", { mode: "timestamp_ms" }),
-      scope: sqliteText("scope"),
-      password: sqliteText("password"),
-      createdAt: integer("created_at", { mode: "timestamp_ms" }).notNull(),
-      updatedAt: integer("updated_at", { mode: "timestamp_ms" }).notNull(),
-    });
+  ? pgTable(
+      "account",
+      {
+        id: pgText("id").primaryKey(),
+        accountId: pgText("account_id").notNull(),
+        providerId: pgText("provider_id").notNull(),
+        issuer: pgText("issuer").notNull(),
+        userId: pgText("user_id").notNull(),
+        accessToken: pgText("access_token"),
+        refreshToken: pgText("refresh_token"),
+        idToken: pgText("id_token"),
+        accessTokenExpiresAt: timestamp("access_token_expires_at"),
+        refreshTokenExpiresAt: timestamp("refresh_token_expires_at"),
+        scope: pgText("scope"),
+        password: pgText("password"),
+        createdAt: timestamp("created_at").notNull(),
+        updatedAt: timestamp("updated_at").notNull(),
+      },
+      (table) => [pgUniqueIndex("account_issuer_accountId_uidx").on(table.issuer, table.accountId)],
+    )
+  : sqliteTable(
+      "account",
+      {
+        id: sqliteText("id").primaryKey(),
+        accountId: sqliteText("account_id").notNull(),
+        providerId: sqliteText("provider_id").notNull(),
+        issuer: sqliteText("issuer").notNull(),
+        userId: sqliteText("user_id").notNull(),
+        accessToken: sqliteText("access_token"),
+        refreshToken: sqliteText("refresh_token"),
+        idToken: sqliteText("id_token"),
+        accessTokenExpiresAt: integer("access_token_expires_at", { mode: "timestamp_ms" }),
+        refreshTokenExpiresAt: integer("refresh_token_expires_at", { mode: "timestamp_ms" }),
+        scope: sqliteText("scope"),
+        password: sqliteText("password"),
+        createdAt: integer("created_at", { mode: "timestamp_ms" }).notNull(),
+        updatedAt: integer("updated_at", { mode: "timestamp_ms" }).notNull(),
+      },
+      (table) => [sqliteUniqueIndex("account_issuer_accountId_uidx").on(table.issuer, table.accountId)],
+    );
 
 export const verification = $$.BATI.has("postgres")
   ? pgTable("verification", {

--- a/boilerplates/better-auth/files/database/migrations/$better-auth.sql.ts
+++ b/boilerplates/better-auth/files/database/migrations/$better-auth.sql.ts
@@ -5,7 +5,7 @@ import type { TransformerProps } from "@batijs/core";
 // owns these tables instead (see ../drizzle/schema/auth.ts); on other engines the `better-auth:migrate`
 // script creates them programmatically.
 // Column types follow Better Auth's SQLite mapping (string→text, boolean→integer, date→date).
-// Keep in sync with `npx @better-auth/cli generate` if you customize the Better Auth config.
+// Keep in sync with `npx auth generate` if you customize the Better Auth config.
 export default function getMigration(props: TransformerProps): string | undefined {
   if (!props.meta.BATI.hasD1 || props.meta.BATI.has("drizzle")) return undefined;
 
@@ -35,6 +35,7 @@ CREATE TABLE IF NOT EXISTS "account" (
   "id" text NOT NULL PRIMARY KEY,
   "accountId" text NOT NULL,
   "providerId" text NOT NULL,
+  "issuer" text NOT NULL,
   "userId" text NOT NULL REFERENCES "user" ("id"),
   "accessToken" text,
   "refreshToken" text,
@@ -46,6 +47,8 @@ CREATE TABLE IF NOT EXISTS "account" (
   "createdAt" date NOT NULL DEFAULT CURRENT_TIMESTAMP,
   "updatedAt" date NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
+
+CREATE UNIQUE INDEX IF NOT EXISTS "account_issuer_accountId_uidx" ON "account" ("issuer", "accountId");
 
 CREATE TABLE IF NOT EXISTS "verification" (
   "id" text NOT NULL PRIMARY KEY,

--- a/boilerplates/better-auth/package.json
+++ b/boilerplates/better-auth/package.json
@@ -28,7 +28,7 @@
     "tsx": "^4.23.12"
   },
   "dependencies": {
-    "better-auth": "^1.6.26"
+    "better-auth": "^1.7.1"
   },
   "files": [
     "dist/"

--- a/boilerplates/react-better-auth/package.json
+++ b/boilerplates/react-better-auth/package.json
@@ -16,7 +16,7 @@
     "@batijs/core": "workspace:*",
     "@types/node": "^20.19.37",
     "@types/react": "^19.2.18",
-    "better-auth": "^1.6.26",
+    "better-auth": "^1.7.1",
     "react": "^19.2.8",
     "vike": "0.4.260",
     "vike-react": "^0.6.25"

--- a/boilerplates/react-sentry/files/pages/sentry/+Page.tsx
+++ b/boilerplates/react-sentry/files/pages/sentry/+Page.tsx
@@ -1,21 +1,21 @@
 import * as Sentry from "@sentry/react";
-import { useEffect, useState } from "react";
+import { useEffect, useSyncExternalStore } from "react";
+
+const subscribe = () => () => {};
 
 export default function ReactSentryErrorPage() {
-  const [sentryClientStatus, setSentryClientStatus] = useState({
-    client_not_loaded: false,
-    enabled: true,
-    dsn_missing: false,
-  });
+  // Sentry is initialized in the browser only, so read its client via useSyncExternalStore:
+  // the server (and hydration) snapshot has no client, and the page re-renders with the real
+  // client state right after hydration — without a setState inside an effect.
+  const options = useSyncExternalStore(subscribe, () => Sentry?.getClient()?.getOptions(), () => undefined);
+  const sentryClientStatus = {
+    client_not_loaded: !options,
+    dsn_missing: (options?.dsn?.length ?? 0) < 2,
+    enabled: options?.enabled ?? true,
+  };
   useEffect(() => {
-    const options = Sentry?.getClient()?.getOptions();
-    setSentryClientStatus({
-      client_not_loaded: !options,
-      dsn_missing: (options?.dsn?.length ?? 0) < 2,
-      enabled: options?.enabled ?? true,
-    });
     console.log("Sentry DSN: ", options?.dsn);
-  }, []);
+  }, [options]);
 
   return (
     <>

--- a/boilerplates/solid-better-auth/package.json
+++ b/boilerplates/solid-better-auth/package.json
@@ -15,7 +15,7 @@
     "@batijs/compile": "workspace:*",
     "@batijs/core": "workspace:*",
     "@types/node": "^20.19.37",
-    "better-auth": "^1.6.26",
+    "better-auth": "^1.7.1",
     "solid-js": "^1.9.14",
     "vike": "0.4.260",
     "vike-solid": "^0.8.3"

--- a/boilerplates/vue-better-auth/package.json
+++ b/boilerplates/vue-better-auth/package.json
@@ -15,7 +15,7 @@
     "@batijs/compile": "workspace:*",
     "@batijs/core": "workspace:*",
     "@types/node": "^20.19.37",
-    "better-auth": "^1.6.26",
+    "better-auth": "^1.7.1",
     "vike": "0.4.260",
     "vike-vue": "^0.9.13",
     "vue": "^3.5.41"

--- a/bun.lock
+++ b/bun.lock
@@ -69,7 +69,7 @@
       "name": "@batijs/better-auth",
       "version": "0.0.1",
       "dependencies": {
-        "better-auth": "^1.6.26",
+        "better-auth": "^1.7.1",
       },
       "devDependencies": {
         "@batijs/compile": "workspace:*",
@@ -478,7 +478,7 @@
         "@batijs/core": "workspace:*",
         "@types/node": "^20.19.37",
         "@types/react": "^19.2.18",
-        "better-auth": "^1.6.26",
+        "better-auth": "^1.7.1",
         "react": "^19.2.8",
         "vike": "0.4.260",
         "vike-react": "^0.6.25",
@@ -635,7 +635,7 @@
         "@batijs/compile": "workspace:*",
         "@batijs/core": "workspace:*",
         "@types/node": "^20.19.37",
-        "better-auth": "^1.6.26",
+        "better-auth": "^1.7.1",
         "solid-js": "^1.9.14",
         "vike": "0.4.260",
         "vike-solid": "^0.8.3",
@@ -795,7 +795,7 @@
         "@batijs/compile": "workspace:*",
         "@batijs/core": "workspace:*",
         "@types/node": "^20.19.37",
-        "better-auth": "^1.6.26",
+        "better-auth": "^1.7.1",
         "vike": "0.4.260",
         "vike-vue": "^0.9.13",
         "vue": "^3.5.41",
@@ -1200,19 +1200,19 @@
 
     "@batijs/vue-sentry": ["@batijs/vue-sentry@workspace:boilerplates/vue-sentry"],
 
-    "@better-auth/core": ["@better-auth/core@1.6.26", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.39.0", "@standard-schema/spec": "^1.1.0", "zod": "^4.3.6" }, "peerDependencies": { "@better-auth/utils": "0.4.2", "@better-fetch/fetch": "1.3.1", "@cloudflare/workers-types": ">=4", "@opentelemetry/api": "^1.9.0", "better-call": "1.3.7", "jose": "^6.1.0", "kysely": "^0.28.5 || ^0.29.0", "nanostores": "^1.0.1" }, "optionalPeers": ["@cloudflare/workers-types", "@opentelemetry/api"] }, "sha512-Ud4FqnjIJDvmeo+3bN+OsuVVAiuvFjNERbW7G8/65ictSxCox62gNgTOsJ4YXmbwXzBzyyekStzrupg2qNGEkA=="],
+    "@better-auth/core": ["@better-auth/core@1.7.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.41.1", "@standard-schema/spec": "^1.1.0", "zod": "^4.3.6" }, "peerDependencies": { "@better-auth/utils": "0.4.2", "@better-fetch/fetch": "1.3.1", "@cloudflare/workers-types": ">=4", "@opentelemetry/api": "^1.9.0", "better-call": "1.4.0", "jose": "^6.1.0", "kysely": "^0.28.5 || ^0.29.0", "nanostores": "^1.0.1" }, "optionalPeers": ["@cloudflare/workers-types", "@opentelemetry/api"] }, "sha512-eZ9lqcnVLMZ3QtUByRo4VZqkB1ESyRddd9NfWjBdDPgh+jcwLScoIUAqhtHLR8zaSUJZah8OLGlkzObyPdUH7A=="],
 
-    "@better-auth/drizzle-adapter": ["@better-auth/drizzle-adapter@1.6.26", "", { "peerDependencies": { "@better-auth/core": "^1.6.26", "@better-auth/utils": "0.4.2", "drizzle-orm": "^0.45.2" }, "optionalPeers": ["drizzle-orm"] }, "sha512-SMvAeeUqEsz0BLtWVVp+HdStAVOwcxs4vPkL/AVmFJ0e9dDKItXl881xWeB/Ze4NgBW6NYmUId9qI4LrdQu3hA=="],
+    "@better-auth/drizzle-adapter": ["@better-auth/drizzle-adapter@1.7.1", "", { "peerDependencies": { "@better-auth/core": "^1.7.1", "@better-auth/utils": "0.4.2", "drizzle-orm": "^0.45.2 || >=1.0.0-rc.1 <2.0.0" }, "optionalPeers": ["drizzle-orm"] }, "sha512-qlqNyg5V9bXHSP68/vtlsiZayhR4hgvEGiS/E3SIj8bCpWWFGmyQkxJbQCqpBmC7vT30wE/kNtJMHIgnV3rkiw=="],
 
-    "@better-auth/kysely-adapter": ["@better-auth/kysely-adapter@1.6.26", "", { "peerDependencies": { "@better-auth/core": "^1.6.26", "@better-auth/utils": "0.4.2", "kysely": "^0.28.17 || ^0.29.0" }, "optionalPeers": ["kysely"] }, "sha512-Y0Kdqn8JQMR8dHMtUnbBNqq7Mk8mDf18DwTves2uhjtRfcOWByVTGxsFMDVUbedMuoM+Ab+v04bwCk94sAo8NA=="],
+    "@better-auth/kysely-adapter": ["@better-auth/kysely-adapter@1.7.1", "", { "peerDependencies": { "@better-auth/core": "^1.7.1", "@better-auth/utils": "0.4.2", "kysely": "^0.28.17 || ^0.29.0" }, "optionalPeers": ["kysely"] }, "sha512-yWCpE1cZpMUj37nD6JFDK+GDR8zS37L5WI73il3qbU9TXtWsxUQKc/5c3IHsHizWQsmcQI8uv2pAFKxsRDa+AQ=="],
 
-    "@better-auth/memory-adapter": ["@better-auth/memory-adapter@1.6.26", "", { "peerDependencies": { "@better-auth/core": "^1.6.26", "@better-auth/utils": "0.4.2" } }, "sha512-kb5ahphEp9jyMleXU4T8I/xgWPa8gjOLFKKsnaVqR/BU+h7xqTOsjJwTY3evY+PFYHvjNFUlrjZ1Km8A/w1p/w=="],
+    "@better-auth/memory-adapter": ["@better-auth/memory-adapter@1.7.1", "", { "peerDependencies": { "@better-auth/core": "^1.7.1", "@better-auth/utils": "0.4.2" } }, "sha512-6NX1yv88DeqdoG7owYFqKwlrDGaIPhsC52JUGrUgeGVKyOq8a/6hHlHsqG1C2FwT23SHQiKVYCEAG9N6aH5OvQ=="],
 
-    "@better-auth/mongo-adapter": ["@better-auth/mongo-adapter@1.6.26", "", { "peerDependencies": { "@better-auth/core": "^1.6.26", "@better-auth/utils": "0.4.2", "mongodb": "^6.0.0 || ^7.0.0" }, "optionalPeers": ["mongodb"] }, "sha512-jYGhuIQqj48h69ROLPYdc8jgqDaMmRRLLFiRViZFYarNyBuYUV07DywJXvRuw8l9ADx+M1TB+BJZGnLE2nnmwQ=="],
+    "@better-auth/mongo-adapter": ["@better-auth/mongo-adapter@1.7.1", "", { "peerDependencies": { "@better-auth/core": "^1.7.1", "@better-auth/utils": "0.4.2", "mongodb": "^6.0.0 || ^7.0.0" }, "optionalPeers": ["mongodb"] }, "sha512-9ILTcNqhG37QK//qR4UhYLyKzNqq6w6zVTf5KX6xkiTjNcV7Oh1yS31lkIJEVTqRNcy9AoV6FZMW6Bbsm8IMDA=="],
 
-    "@better-auth/prisma-adapter": ["@better-auth/prisma-adapter@1.6.26", "", { "peerDependencies": { "@better-auth/core": "^1.6.26", "@better-auth/utils": "0.4.2", "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0", "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0" }, "optionalPeers": ["@prisma/client", "prisma"] }, "sha512-ILQoYmnoYyghDP4iN1h/Gkd9Jt7Xs/vxoNAt4AuuJJbqs73u27LlQM4P1YiP7nJ+bM1iVTBI1dDF73myIAtjzQ=="],
+    "@better-auth/prisma-adapter": ["@better-auth/prisma-adapter@1.7.1", "", { "peerDependencies": { "@better-auth/core": "^1.7.1", "@better-auth/utils": "0.4.2", "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0", "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0" }, "optionalPeers": ["@prisma/client", "prisma"] }, "sha512-ZiUcafQ85InAofcUjyGgCPjKLfQjXr9SvDmMjuFUW8oEbreA6C6GaFAEA77VuV2doZUQlzvQQ4gCoTmS28W92A=="],
 
-    "@better-auth/telemetry": ["@better-auth/telemetry@1.6.26", "", { "peerDependencies": { "@better-auth/core": "^1.6.26", "@better-auth/utils": "0.4.2", "@better-fetch/fetch": "1.3.1" } }, "sha512-pBs69RORUSJHRF9r5PdeY7pzLRga09YSWew8igFYrBvT2tLt7DktrbD5WjryLZpAZOuKAMZ+Xo0DlJbnvLWGpQ=="],
+    "@better-auth/telemetry": ["@better-auth/telemetry@1.7.1", "", { "peerDependencies": { "@better-auth/core": "^1.7.1", "@better-auth/utils": "0.4.2", "@better-fetch/fetch": "1.3.1" } }, "sha512-kLKjMfFlTbyt49DGeI9okHAsn0MtBZcMoQYKaEdgR0H3BHzqqyzePcQz/hxAmRgjB4p/6inise3zJwhX0sgXrQ=="],
 
     "@better-auth/utils": ["@better-auth/utils@0.4.2", "", { "dependencies": { "@noble/hashes": "^2.0.1" } }, "sha512-AUxrvu+HaaODsUyzDxFgwd/8RZ1yZaYo42LXKSrU2oGgR38pS1ij8nqQKNgtTWoYGpNevNXtCfgTy6loHveW9A=="],
 
@@ -2528,9 +2528,9 @@
 
     "better-ajv-errors": ["better-ajv-errors@1.2.0", "", { "dependencies": { "@babel/code-frame": "^7.16.0", "@humanwhocodes/momoa": "^2.0.2", "chalk": "^4.1.2", "jsonpointer": "^5.0.0", "leven": "^3.1.0 < 4" }, "peerDependencies": { "ajv": "4.11.8 - 8" } }, "sha512-UW+IsFycygIo7bclP9h5ugkNH8EjCSgqyFB/yQ4Hqqa1OEYDtb0uFIkYE0b6+CjkgJYVM5UKI/pJPxjYe9EZlA=="],
 
-    "better-auth": ["better-auth@1.6.26", "", { "dependencies": { "@better-auth/core": "1.6.26", "@better-auth/drizzle-adapter": "1.6.26", "@better-auth/kysely-adapter": "1.6.26", "@better-auth/memory-adapter": "1.6.26", "@better-auth/mongo-adapter": "1.6.26", "@better-auth/prisma-adapter": "1.6.26", "@better-auth/telemetry": "1.6.26", "@better-auth/utils": "0.4.2", "@better-fetch/fetch": "1.3.1", "@noble/ciphers": "^2.1.1", "@noble/hashes": "^2.0.1", "better-call": "1.3.7", "defu": "^6.1.4", "jose": "^6.1.3", "kysely": "^0.28.17 || ^0.29.0", "nanostores": "^1.1.1", "zod": "^4.3.6" }, "peerDependencies": { "@lynx-js/react": "*", "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0", "@sveltejs/kit": "^2.0.0", "@tanstack/react-start": "^1.0.0", "@tanstack/solid-start": "^1.0.0", "better-sqlite3": "^12.0.0", "drizzle-kit": ">=0.31.4", "drizzle-orm": "^0.45.2", "mongodb": "^6.0.0 || ^7.0.0", "mysql2": "^3.0.0", "next": "^14.0.0 || ^15.0.0 || ^16.0.0", "pg": "^8.0.0", "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0", "solid-js": "^1.0.0", "svelte": "^4.0.0 || ^5.0.0", "vitest": "^2.0.0 || ^3.0.0 || ^4.0.0", "vue": "^3.0.0" }, "optionalPeers": ["@lynx-js/react", "@prisma/client", "@sveltejs/kit", "@tanstack/react-start", "@tanstack/solid-start", "better-sqlite3", "drizzle-kit", "drizzle-orm", "mongodb", "mysql2", "next", "pg", "prisma", "react", "react-dom", "solid-js", "svelte", "vitest", "vue"] }, "sha512-nhXWrDDj+EnZsHq1j0z1c6DowOMFZWZHe6LCaXbBfLIgHHZm6dyazBQcbRspM4spUIcUt250Mc1BFOSuP7eniQ=="],
+    "better-auth": ["better-auth@1.7.1", "", { "dependencies": { "@better-auth/core": "1.7.1", "@better-auth/drizzle-adapter": "1.7.1", "@better-auth/kysely-adapter": "1.7.1", "@better-auth/memory-adapter": "1.7.1", "@better-auth/mongo-adapter": "1.7.1", "@better-auth/prisma-adapter": "1.7.1", "@better-auth/telemetry": "1.7.1", "@better-auth/utils": "0.4.2", "@better-fetch/fetch": "1.3.1", "@noble/ciphers": "^2.2.0", "@noble/hashes": "^2.2.0", "better-call": "1.4.0", "defu": "^6.1.4", "jose": "^6.2.3", "kysely": "^0.28.17 || ^0.29.0", "nanostores": "^1.3.0", "zod": "^4.3.6" }, "peerDependencies": { "@lynx-js/react": "*", "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0", "@sveltejs/kit": "^2.0.0", "@tanstack/react-start": "^1.0.0", "@tanstack/solid-start": "^1.0.0", "better-sqlite3": "^12.0.0", "drizzle-kit": ">=0.31.4 || >=1.0.0-beta.1", "drizzle-orm": "^0.45.2 || >=1.0.0-rc.1 <2.0.0", "mongodb": "^6.0.0 || ^7.0.0", "mysql2": "^3.0.0", "next": "^14.0.0 || ^15.0.0 || ^16.0.0", "pg": "^8.0.0", "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0", "solid-js": "^1.0.0", "svelte": "^4.0.0 || ^5.0.0", "vitest": "^2.0.0 || ^3.0.0 || ^4.0.0", "vue": "^3.0.0" }, "optionalPeers": ["@lynx-js/react", "@prisma/client", "@sveltejs/kit", "@tanstack/react-start", "@tanstack/solid-start", "better-sqlite3", "drizzle-kit", "drizzle-orm", "mongodb", "mysql2", "next", "pg", "prisma", "react", "react-dom", "solid-js", "svelte", "vitest", "vue"] }, "sha512-g8WlTQijxXWJjPVZfFu1+EJg9cwwHrKDmIkcYMzx8CzYA+tDxl6NI7qQbKkbgw5UtHILsT5VH+RMzFzwnVJqAg=="],
 
-    "better-call": ["better-call@1.3.7", "", { "dependencies": { "@better-auth/utils": "^0.4.0", "@better-fetch/fetch": "^1.1.21", "rou3": "^0.7.12", "set-cookie-parser": "^3.0.1" }, "peerDependencies": { "zod": "^4.0.0" }, "optionalPeers": ["zod"] }, "sha512-Al51/hjp2SSp6CRTa3F2ptcx4yQVS1xWKoY6jcVXqNYOap6mHFP2jUBn5EwIL4iIed1/Sq4hlQ+Umm6EflZG+w=="],
+    "better-call": ["better-call@1.4.0", "", { "dependencies": { "@better-auth/utils": "^0.5.0", "@better-fetch/fetch": "^1.3.1", "rou3": "^0.9.1", "set-cookie-parser": "^3.1.2" }, "peerDependencies": { "zod": "^4.0.0" }, "optionalPeers": ["zod"] }, "sha512-bBKOT4vv1kZLDgxVePdilk/Jwkn+dtRRsmi3DzHcDP+WnswyVl6dR59l2HEeP/0cB+bDoopASAesWDPIdd/zZA=="],
 
     "better-result": ["better-result@2.9.2", "", {}, "sha512-WIFoBPCdnTOdk9inkE1ZRvCZ4P0CpSkAiLlchC65N7n9DcjZ3NhqkBOlafzpOVnO8ixyi37kicmSJ3ENhPZl7Q=="],
 
@@ -4056,7 +4056,7 @@
 
     "rolldown-plugin-dts": ["rolldown-plugin-dts@0.28.1", "", { "dependencies": { "dts-resolver": "^3.0.0", "get-tsconfig": "5.0.0-beta.5", "obug": "^2.1.4", "yuku-ast": "^0.8.4", "yuku-codegen": "^0.8.4", "yuku-parser": "^0.8.4" }, "peerDependencies": { "@typescript/native-preview": "*", "@volar/typescript": "~2.4.0", "rolldown": "^1.2.0", "typescript": "^5.0.0 || ^6.0.0 || ~7.0.0", "vue-tsc": "~3.2.0 || ~3.3.0" }, "optionalPeers": ["@typescript/native-preview", "@volar/typescript", "typescript", "vue-tsc"] }, "sha512-/L3joWaepvZehTxe0w+9xoo7xVxgXFb8XBnn8fXsbsliHbYju0CDEhvq6TXFoLn51vNIJergXxMGE480UxUrww=="],
 
-    "rou3": ["rou3@0.7.12", "", {}, "sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg=="],
+    "rou3": ["rou3@0.9.2", "", {}, "sha512-3SOzvaAg8rkHrXtRjpCvCvbyO5to9oOO27Z/XqHEYXfMRVSw/qMIVdmaOk9W2lcRLtR6dlqTjo9hDeJk70QBYQ=="],
 
     "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
 
@@ -4102,7 +4102,7 @@
 
     "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
 
-    "set-cookie-parser": ["set-cookie-parser@3.1.0", "", {}, "sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw=="],
+    "set-cookie-parser": ["set-cookie-parser@3.1.2", "", {}, "sha512-5/r/lTwbJ3zQ+qwdUFZYeRNqda7P5HD8zQKqlSjdGt1/S0cjLAphHusj4Y58ahDtWn/g32xrIS58/ikOvwl0Lw=="],
 
     "set-function-length": ["set-function-length@1.2.2", "", { "dependencies": { "define-data-property": "^1.1.4", "es-errors": "^1.3.0", "function-bind": "^1.1.2", "get-intrinsic": "^1.2.4", "gopd": "^1.0.1", "has-property-descriptors": "^1.0.2" } }, "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg=="],
 
@@ -5014,6 +5014,8 @@
 
     "better-auth/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
+    "better-call/@better-auth/utils": ["@better-auth/utils@0.5.0", "", { "dependencies": { "@noble/hashes": "^2.0.1" } }, "sha512-BL8W4EfIZFwlu0r54m3v1ztjDhu6dDe/amLTm0xybmbZaNgYUqhD3SjpAsnq0q8YD6/ki4iwIgxJNLP/N3TxiA=="],
+
     "c12/chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
 
     "c12/confbox": ["confbox@0.2.4", "", {}, "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ=="],
@@ -5467,6 +5469,8 @@
     "@compiled/css/postcss/nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
 
     "@edgeone/vite/@universal-deploy/store/@universal-middleware/express": ["@universal-middleware/express@0.4.27", "", { "dependencies": { "@universal-middleware/core": "^0.4.17", "@universal-middleware/node": "^0.2.0" } }, "sha512-leJeb617DqDmwVqTFtPg9YISlYiln6B6Srq8GFo01aNmwGqt5rqA6f0nP4TU9lFdKekUAMZ932I3n6BZWkOItg=="],
+
+    "@edgeone/vite/@universal-deploy/store/rou3": ["rou3@0.7.12", "", {}, "sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg=="],
 
     "@esbuild-kit/core-utils/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.18.20", "", { "os": "android", "cpu": "arm" }, "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw=="],
 


### PR DESCRIPTION
## Description

Follow-up to the two pre-existing e2e failures documented on [#791](https://github.com/vikejs/bati/pull/791) ([better-auth](https://github.com/vikejs/bati/pull/791#issuecomment-5413863968), [oxlint](https://github.com/vikejs/bati/pull/791#issuecomment-5413899375)). Both break freshly generated apps on `main` today because fresh installs resolve newer upstream releases.

### better-auth 1.7: required `account.issuer` column

better-auth 1.7 (released 2026-08-18) scopes account identity by a new required `issuer` column, unique together with `accountId` ([upgrade guide](https://better-auth.com/docs/guides/1-7-upgrade-guide#account-identity-is-scoped-by-issuer)). Generated apps resolved 1.7.x via `^1.6.26`, so sign-up crashed with `The field "issuer" does not exist in the "account" Drizzle schema` on drizzle scaffolds, and the cloudflare D1 no-ORM migration created an `account` table the runtime cannot insert into.

- `boilerplates/better-auth/files/database/drizzle/schema/auth.ts`: add `issuer` (pg + sqlite) and the `account_issuer_accountId_uidx` unique index on `(issuer, accountId)`, matching `npx auth generate` output.
- `boilerplates/better-auth/files/database/migrations/$better-auth.sql.ts` (cloudflare D1 without ORM): add `"issuer" text NOT NULL` and the same unique index.
- Point the regenerate hints at the renamed `npx auth generate` CLI — the old `@better-auth/cli` still emits the pre-1.7 schema without `issuer`.
- Raise the `better-auth` floor to `^1.7.1` in the four boilerplates that declare it: a 1.6 client would never populate the now `NOT NULL` column.

The other engines (kysely / no-ORM via `better-auth:migrate`) use better-auth's own migrator and already produce the 1.7 schema.

### oxlint 1.80: `react(set-state-in-effect)` on the sentry demo page

oxlint 1.80 (resolved via `^1.78.0`) warns on the mount effect in `boilerplates/react-sentry/files/pages/sentry/+Page.tsx`, and the generated lint script runs with `--max-warnings 0`. Replaced the effect+setState with `useSyncExternalStore`: the server and hydration snapshots have no Sentry client, and the page re-renders with the real client state right after hydration. This was the only react boilerplate file using the pattern.

## Validation

- `bun run build`, `bun run test`, `bun run check-types`, `bun run lint` all pass.
- Generated the three previously failing combos from this branch's build and verified them end-to-end (this sandbox can't run the e2e port allocator, so the spec's exact steps were replicated manually):
  - `solid+fastify+better-auth+sqlite+drizzle`: `drizzle:generate` + `drizzle:migrate` produce the `issuer` column and unique index; sign-up 200, sign-in 200, wrong password 401; eslint/biome/oxlint/tsc/knip all pass.
  - `react+hono+cloudflare+better-auth+sqlite` (D1, no ORM): `d1:migrate` applies cleanly; the same auth flow passes against workerd (200/200/401).
  - `react+sentry+eslint+biome+oxlint`: oxlint/eslint/biome/tsc/knip all pass; `/` and `/sentry` render correctly in dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RisVvvRs9isNMhmFqyo1i1

---
_Generated by [Claude Code](https://claude.ai/code/session_01RisVvvRs9isNMhmFqyo1i1)_